### PR TITLE
docs: add CLAUDE.md and backend data model reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,81 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Rust CLI tool for analyzing and validating SODAX backend data. It queries a local MongoDB instance (containing SODAX backend data) and validates it against on-chain state via EVM RPC calls. Requires a running local MongoDB and an accessible RPC endpoint.
+
+## Build & Development Commands
+
+```bash
+cargo build                    # Build (debug)
+cargo build --release          # Build (release)
+cargo run -- --help            # Run with flags
+cargo check                    # Check compilation
+cargo clippy                   # Lint
+cargo fmt                      # Format code
+cargo test                     # Run all tests (requires running MongoDB)
+cargo test --test mongodb_integration_tests   # Run specific test file
+cargo test -- --nocapture      # Tests with stdout visible
+```
+
+Make targets: `make build`, `make lint`, `make fmt`, `make test`, `make clean`
+
+## Code Formatting
+
+Uses `rustfmt.toml`: 2-space indentation (`tab_spaces = 2`), max width 100, imports are NOT reordered (`reorder_imports = false`).
+
+## Pre-commit Hooks
+
+cargo-husky runs `cargo check` and `cargo clippy` on pre-commit.
+
+## Architecture
+
+**CLI flow:** `main.rs` → `cli::parse_args()` → returns `Vec<Flag>` → `main` dispatches to handler functions.
+
+- **`structs.rs`** — `Flag` enum defines all CLI flags (some carry String/u64 values). Also defines validation result types (`EntryState`, `UserPositionValidation`, `ReserveEntryState`) and `Collections` (MongoDB collection name constants).
+- **`cli.rs`** — Hand-rolled argument parser. Flags are standalone or combinable (e.g., `--balance-of <addr> --reserve-token <addr>`). Validation rules enforce which flags can combine.
+- **`handlers.rs`** — One handler function per CLI command. Handlers orchestrate DB queries, EVM calls, and validation. Bulk operations use `tokio` with semaphore-based concurrency limiting (10 concurrent users, 5 positions per user).
+- **`validators.rs`** — Validation logic comparing database values against on-chain state. Supports both real balances (index-adjusted) and scaled balances (raw).
+- **`db.rs`** — MongoDB queries against collections: `reserve_tokens`, `user_positions`, `orderbook`, `money_market_events`, `wallet_factory_events`, `intent_events`, etc.
+- **`evm.rs`** — On-chain calls via `alloy` crate (block numbers, token balances, contract reads).
+- **`models.rs`** — MongoDB document schemas (serde deserialization).
+- **`config.rs`** — Loads `.env` vars (`MONGO_USER`, `MONGO_PASSWORD`, `MONGO_HOST`, `MONGO_PORT`, `MONGO_DB`, `RPC_PROVIDER`).
+- **`balance_calculator.rs`** — Balance computation from event history.
+- **`functions.rs`** — Flag extraction helpers (e.g., extracting address from a `Flag` variant).
+- **`helpers.rs`** — Utility functions.
+- **`constants.rs`** — Global constants and help text.
+
+## Key Patterns
+
+- The `Flag` enum is the central dispatch mechanism — adding a new CLI command means adding a variant to `Flag`, parsing logic in `cli.rs`, a handler in `handlers.rs`, and a dispatch branch in `main.rs`.
+- Balance validation compares `database_amount` vs `on_chain_amount` and computes difference/percentage via `EntryState`.
+- The `--scaled` flag toggles between real balance validation (applies liquidity/borrow index) and raw scaled balance validation.
+- MongoDB collection names are centralized in `Collections::new()` in `structs.rs`.
+
+## Environment
+
+Requires a `.env` file with: `MONGO_USER`, `MONGO_PASSWORD`, `MONGO_HOST`, `MONGO_PORT`, `MONGO_DB`, `RPC_PROVIDER`.
+
+## Testing
+
+All tests are integration tests requiring a running MongoDB with SODAX data. Test files are in `tests/` with shared utilities in `tests/common.rs`.
+
+## SODAX Backend Data Model Reference
+
+Detailed reference docs for the backend's MongoDB data model live in `docs/sodax-backend/`:
+
+| File | Contents |
+|------|----------|
+| [`COLLECTIONS.md`](docs/sodax-backend/COLLECTIONS.md) | Every collection with exact field names, types, indexes, discriminator patterns |
+| [`ENUMS.md`](docs/sodax-backend/ENUMS.md) | All enum values (event types, chain IDs, statuses, intervals) |
+| [`DATA_FLOW.md`](docs/sodax-backend/DATA_FLOW.md) | Architecture diagram, write ownership table, domain rules |
+
+**Key gotchas:**
+
+- **Collection names are snake_case** in MongoDB (e.g., `intent_events`, `user_positions`). Verify `Collections::new()` in `structs.rs` matches — any camelCase names there (like `"intentEvents"`) may be legacy bugs.
+- **All BigInt fields are stored as `Decimal128`** in MongoDB. Deserialize via `bson::Decimal128` then convert to `u128`/`U256`.
+- **Event collections use discriminators** on the `eventType` field — different variants have different fields present. Always filter by `eventType` when querying.
+- **`intentId` is NOT unique** — always use `intentHash` as the unique intent identifier.
+- **Scaled balance math**: `user_positions` stores scaled (not real) balances. Real balance = `scaledBalance × currentIndex / 10^27`.

--- a/docs/sodax-backend/COLLECTIONS.md
+++ b/docs/sodax-backend/COLLECTIONS.md
@@ -1,0 +1,603 @@
+# SODAX Backend — MongoDB Collection Reference
+
+All collections the backend writes to MongoDB. Field names are the **actual MongoDB keys** (camelCase, matching serde deserialization).
+
+**Type conventions:**
+- `Decimal128` in MongoDB → deserialize as `bson::Decimal128`, convert to `u128` or `U256` in Rust
+- `Address` = 42-char hex string (`0x...`), stored lowercase
+- `Hash` = 66-char hex string (`0x...`)
+- All event collections share unique index `{ chainId, txHash, logIndex }`
+
+---
+
+## Raw Event Collections
+
+### `intent_events`
+**Writer:** data-aggregator (intents) | **Discriminator key:** `eventType`
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `_id` | ObjectId | |
+| `txHash` | String | lowercase, indexed |
+| `logIndex` | Number | |
+| `chainId` | Number | |
+| `blockNumber` | Number | |
+| `intentHash` | String (Hash) | |
+| `eventType` | String | discriminator — see below |
+
+**Unique index:** `{ chainId: 1, txHash: 1, logIndex: 1 }`
+
+**Discriminator variants:**
+
+#### `eventType = "intent-created"`
+| Field | Type | Notes |
+|-------|------|-------|
+| `intent.intentId` | String | NOT unique across intents |
+| `intent.creator` | String (Address) | |
+| `intent.inputToken` | String (Address) | |
+| `intent.outputToken` | String (Address) | |
+| `intent.inputAmount` | Decimal128 | |
+| `intent.minOutputAmount` | Decimal128 | |
+| `intent.deadline` | Decimal128 | |
+| `intent.allowPartialFill` | Boolean | |
+| `intent.srcChain` | Number | |
+| `intent.dstChain` | Number | |
+| `intent.srcAddress` | String (Address) | |
+| `intent.dstAddress` | String (Address) | |
+| `intent.solver` | String (Address) | |
+| `intent.data` | String (Hash) | |
+
+#### `eventType = "intent-filled"`
+| Field | Type | Notes |
+|-------|------|-------|
+| `intentState.exists` | Boolean | |
+| `intentState.remainingInput` | Decimal128 | |
+| `intentState.receivedOutput` | Decimal128 | |
+| `intentState.pendingPayment` | Boolean | |
+
+#### `eventType = "intent-cancelled"`
+No additional fields.
+
+#### `eventType = "external-fill-failed"`
+| Field | Type | Notes |
+|-------|------|-------|
+| `fillId` | Decimal128 | |
+| `inputAmount` | Decimal128 | |
+| `outputAmount` | Decimal128 | |
+| `to` | String (Address) | |
+| `token` | String (Address) | |
+
+---
+
+### `money_market_events`
+**Writer:** data-aggregator (money-market) | **Discriminator key:** `eventType`
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `_id` | ObjectId | |
+| `txHash` | String | lowercase, indexed |
+| `logIndex` | Number | |
+| `chainId` | Number | |
+| `blockNumber` | Number | |
+| `eventType` | String | discriminator — 17 variants |
+
+**Unique index:** `{ chainId: 1, txHash: 1, logIndex: 1 }`
+
+**Key discriminator variants:**
+
+#### `eventType = "supply"` / `"borrow"` / `"repay"` / `"withdraw"`
+| Field | Type | Notes |
+|-------|------|-------|
+| `reserve` | String (Address) | |
+| `user` | String (Address) | |
+| `onBehalfOf` or `repayer` or `to` | String (Address) | varies by type |
+| `amount` | Decimal128 | |
+| `referralCode` | Number | supply/borrow only |
+| `interestRateMode` | Number | borrow only |
+| `borrowRate` | Decimal128 | borrow only |
+| `useATokens` | Boolean | repay only |
+
+#### `eventType = "a-token-mint"` / `"a-token-burn"` / `"debt-token-mint"` / `"debt-token-burn"`
+| Field | Type | Notes |
+|-------|------|-------|
+| `tokenAddress` | String (Address) | |
+| `caller` or `from` | String (Address) | mint=caller, burn=from |
+| `onBehalfOf` or `target` | String (Address) | mint=onBehalfOf, burn=target |
+| `value` | Decimal128 | |
+| `balanceIncrease` | Decimal128 | |
+| `index` | Decimal128 | RAY-scaled (10^27) |
+
+#### `eventType = "a-token-transfer"` / `"a-token-balance-transfer"`
+| Field | Type | Notes |
+|-------|------|-------|
+| `tokenAddress` | String (Address) | |
+| `from` | String (Address) | |
+| `to` | String (Address) | |
+| `value` | Decimal128 | |
+| `index` | Decimal128 | balance-transfer only |
+
+#### `eventType = "reserve-data-updated"`
+| Field | Type | Notes |
+|-------|------|-------|
+| `reserve` | String (Address) | |
+| `liquidityRate` | Decimal128 | |
+| `stableBorrowRate` | Decimal128 | |
+| `variableBorrowRate` | Decimal128 | |
+| `liquidityIndex` | Decimal128 | RAY-scaled |
+| `variableBorrowIndex` | Decimal128 | RAY-scaled |
+
+---
+
+### `amm_events`
+**Writer:** data-aggregator (amm) | **Discriminator key:** `eventType`
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `_id` | ObjectId | |
+| `txHash` | String | lowercase, indexed |
+| `logIndex` | Number | |
+| `chainId` | Number | |
+| `blockNumber` | Number | |
+| `eventType` | String | discriminator |
+
+**Unique index:** `{ chainId: 1, txHash: 1, logIndex: 1 }`
+
+#### `eventType = "swap"`
+| Field | Type |
+|-------|------|
+| `id` | String (pool ID) |
+| `sender` | String (Address) |
+| `amount0` | Decimal128 |
+| `amount1` | Decimal128 |
+| `sqrtPriceX96` | Decimal128 |
+| `liquidity` | Decimal128 |
+| `tick` | Number |
+| `fee` | Number |
+| `protocolFee` | Number |
+
+#### `eventType = "initialize"`
+| Field | Type |
+|-------|------|
+| `id` | String (pool ID) |
+| `currency0` | String (Address) |
+| `currency1` | String (Address) |
+
+#### `eventType = "transfer"`
+| Field | Type |
+|-------|------|
+| `from` | String (Address) |
+| `to` | String (Address) |
+| `id` | Decimal128 (token ID) |
+
+#### `eventType = "mint-position"`
+| Field | Type |
+|-------|------|
+| `tokenId` | Decimal128 |
+
+---
+
+### `wallet_factory_events`
+**Writer:** data-aggregator (wallet-factory) | **Discriminator key:** `eventType`
+
+**Unique index:** `{ chainId: 1, txHash: 1, logIndex: 1 }`
+
+#### `eventType = "deployed"`
+| Field | Type |
+|-------|------|
+| `spokeAddress` | String |
+| `deployedAddress` | String (Address) |
+
+---
+
+### `protocol_revenue_events`
+**Writer:** data-aggregator (protocol-revenue) | **Discriminator key:** `eventType`
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `txHash` | String | lowercase, indexed |
+| `logIndex` | Number | |
+| `chainId` | Number | |
+| `blockNumber` | Number | |
+| `contractAddress` | String (Address) | lowercase |
+| `tokenAddress` | String (Address) | lowercase |
+| `amount` | Decimal128 | |
+| `eventType` | String | discriminator |
+
+**Indexes:**
+- `{ chainId: 1, txHash: 1, logIndex: 1 }` (unique)
+- `{ tokenAddress: 1, blockNumber: 1 }`
+- `{ contractAddress: 1, blockNumber: 1 }`
+
+#### `eventType = "minted-to-treasury"`
+No additional fields.
+
+#### `eventType = "fees-distributed-to-treasury"`
+| Field | Type |
+|-------|------|
+| `treasuryAddress` | String (Address) |
+
+#### `eventType = "fee-collected"`
+No additional fields.
+
+---
+
+### `aggregator_events_metadata`
+**Writer:** data-aggregator
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `address` | String | lowercase, contract address |
+| `chainId` | Number | |
+| `lastBlockNumber` | Decimal128 | last synced block |
+| `aggregator` | String | LogAggregator enum value |
+
+**Unique index:** `{ address: 1, chainId: 1, aggregator: 1 }`
+
+---
+
+## Transformed Collections
+
+### `intent_journal`
+**Writer:** data-transformator
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `intentHash` | String (Hash) | |
+| `txHash` | String (Hash) | creation tx |
+| `logIndex` | Number | |
+| `chainId` | Number | |
+| `blockNumber` | Number | |
+| `open` | Boolean | default: true |
+| `intent` | Object | same shape as intent-created's `intent` |
+| `events` | Array | event history |
+| `events[].eventType` | String | IntentEventType value |
+| `events[].txHash` | String | |
+| `events[].logIndex` | Number | |
+| `events[].blockNumber` | Number | |
+| `events[].intentState` | Object | optional, for filled events |
+| `createdAt` | Date | |
+| `updatedAt` | Date | |
+
+**Indexes:**
+- `{ intentHash: 1, open: 1 }` (unique, partial: `{ open: true }`)
+- `{ intentHash: 1, txHash: 1, logIndex: 1 }` (unique)
+
+---
+
+### `orderbook`
+**Writer:** data-transformator
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `intentState.exists` | Boolean | |
+| `intentState.remainingInput` | Decimal128 | |
+| `intentState.receivedOutput` | Decimal128 | |
+| `intentState.pendingPayment` | Boolean | |
+| `intentData.intentId` | String | NOT unique |
+| `intentData.creator` | String (Address) | |
+| `intentData.inputToken` | String (Address) | |
+| `intentData.outputToken` | String (Address) | |
+| `intentData.inputAmount` | Decimal128 | |
+| `intentData.minOutputAmount` | Decimal128 | |
+| `intentData.deadline` | Decimal128 | |
+| `intentData.allowPartialFill` | Boolean | |
+| `intentData.srcChain` | Number | |
+| `intentData.dstChain` | Number | |
+| `intentData.srcAddress` | String (Address) | |
+| `intentData.dstAddress` | String (Address) | |
+| `intentData.solver` | String (Address) | |
+| `intentData.data` | String (Hash) | |
+| `intentData.intentHash` | String (Hash) | |
+| `intentData.txHash` | String (Hash) | |
+| `intentData.blockNumber` | Number | |
+| `createdAt` | Date | |
+| `updatedAt` | Date | |
+
+**Unique index:** `{ 'intentData.intentHash': 1 }`
+
+---
+
+### `reserve_tokens`
+**Writer:** data-transformator
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `reserveAddress` | String (Address) | unique, lowercase |
+| `symbol` | String | optional |
+| `totalATokenBalance` | Decimal128 | default: 0 |
+| `totalVariableDebtTokenBalance` | Decimal128 | default: 0 |
+| `suppliers` | Array of String | addresses |
+| `borrowers` | Array of String | addresses |
+| `aTokenAddress` | String (Address) | unique, lowercase |
+| `variableDebtTokenAddress` | String (Address) | unique, lowercase |
+| `liquidityRate` | Decimal128 | |
+| `stableBorrowRate` | Decimal128 | |
+| `variableBorrowRate` | Decimal128 | |
+| `liquidityIndex` | Decimal128 | RAY-scaled (10^27) |
+| `variableBorrowIndex` | Decimal128 | RAY-scaled (10^27) |
+| `blockNumber` | Number | last update block |
+| `indexBlockNumber` | Number | last index update block |
+| `createdAt` | Date | |
+| `updatedAt` | Date | |
+
+---
+
+### `user_positions`
+**Writer:** data-transformator
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `userAddress` | String (Address) | unique index |
+| `positions` | Array | per-reserve positions |
+| `positions[].reserveAddress` | String (Address) | |
+| `positions[].aTokenAddress` | String (Address) | |
+| `positions[].variableDebtTokenAddress` | String (Address) | |
+| `positions[].blockNumber` | Number | |
+| `positions[].aTokenBalance` | Decimal128 | scaled balance |
+| `positions[].variableDebtTokenBalance` | Decimal128 | scaled balance |
+| `positions[].aTokenBalanceHistory` | Array | `{ final, delta, eventId }` |
+| `positions[].debtTokenBalanceHistory` | Array | `{ final, delta, eventId }` |
+| `createdAt` | Date | |
+| `updatedAt` | Date | |
+
+**Unique index:** `{ userAddress: 1 }`
+
+---
+
+### `solver_volume`
+**Writer:** data-transformator
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `intentHash` | String (Hash) | |
+| `solver` | String (Address) | |
+| `inputToken` | String (Address) | |
+| `outputToken` | String (Address) | |
+| `amount` | Decimal128 | |
+| `chainId` | Number | |
+| `blockNumber` | Number | |
+| `txHash` | String (Hash) | |
+| `logIndex` | Number | |
+| `timestamp` | Date | |
+| `data` | String (Hash) | |
+| `createdAt` | Date | |
+| `updatedAt` | Date | |
+
+**Unique index:** `{ chainId: 1, txHash: 1, logIndex: 1, blockNumber: 1 }`
+
+---
+
+### `amm_candles`
+**Writer:** data-transformator
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `poolId` | String | |
+| `chainId` | Number | |
+| `interval` | String | `1m`, `5m`, `15m`, `1h`, `4h`, `1d` |
+| `timestamp` | Number | unix epoch |
+| `open` | String | price as string |
+| `high` | String | |
+| `low` | String | |
+| `close` | String | |
+| `volume0` | String | default: "0" |
+| `volume1` | String | default: "0" |
+| `tradeCount` | Number | default: 0 |
+| `createdAt` | Date | |
+| `updatedAt` | Date | |
+
+**Indexes:**
+- `{ chainId: 1, poolId: 1, interval: 1, timestamp: 1 }` (unique)
+- `{ chainId: 1, poolId: 1, interval: 1 }`
+
+---
+
+### `amm_tokens`
+**Writer:** data-transformator
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `chainId` | Number | |
+| `tokenAddress` | String (Address) | |
+| `decimals` | Number | nullable |
+| `symbol` | String | nullable |
+| `name` | String | nullable |
+| `poolIds` | Array of String | default: [] |
+| `createdAt` | Date | |
+| `updatedAt` | Date | |
+
+**Indexes:**
+- `{ chainId: 1, tokenAddress: 1 }` (unique)
+- `{ chainId: 1, poolIds: 1 }`
+
+---
+
+### `amm_nft_positions`
+**Writer:** data-transformator
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `owner` | String (Address) | |
+| `currency0` | String (Address) | nullable |
+| `currency1` | String (Address) | nullable |
+| `poolId200` | String | nullable |
+| `tokenId` | Decimal128 | |
+| `createdAt` | Date | |
+| `updatedAt` | Date | |
+
+**Indexes:**
+- `{ tokenId: 1 }` (unique)
+- `{ owner: 1, tokenId: 1 }`
+
+---
+
+### `partner_asset`
+**Writer:** data-transformator
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `receiver` | String (Address) | |
+| `asset` | String (Address) | |
+| `chainId` | Number | |
+| `lastBlockNumber` | Number | |
+| `outputs` | Map | keyed by solver address |
+| `outputs.<solver>.totalVolumeOut` | Decimal128 | |
+| `outputs.<solver>.totalFeeIn` | Decimal128 | |
+| `outputs.<solver>.txCount` | Number | |
+| `createdAt` | Date | |
+| `updatedAt` | Date | |
+
+**Unique index:** `{ receiver: 1, asset: 1, chainId: 1 }`
+
+---
+
+### `sodax_supply`
+**Writer:** data-aggregator (sodax-supply)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `_id` | String | fixed: `"singleton"` |
+| `block` | String | |
+| `totalSupply` | String | |
+| `lockedSupply` | String | |
+| `circulatingSupply` | String | |
+| `daoFund` | String | |
+| `icxMigration` | String | |
+| `balnMigration` | String | |
+| `createdAt` | Date | |
+| `updatedAt` | Date | |
+
+---
+
+## Metadata Collections (Transformator)
+
+All share the singleton pattern (`_id = "singleton"`) and the same shape:
+
+| Collection | Writer |
+|------------|--------|
+| `intent_journal_metadata` | data-transformator |
+| `money_market_events_metadata` | data-transformator |
+| `amm_events_metadata` | data-transformator |
+| `orderbook_metadata` | data-transformator |
+| `solver_volume_metadata` | data-transformator |
+| `protocol_revenue_events_metadata` | data-transformator |
+
+**Fields:**
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `_id` | String | `"singleton"` |
+| `lastProcessedBlock` | Number | |
+| `processedEventKeys` | Array of String | `"txHash-logIndex"` format |
+| `createdAt` | Date | |
+| `updatedAt` | Date | |
+
+---
+
+## Stateful Collections
+
+### `stateful_users`
+**Writer:** stateful-api
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `address` | String | trimmed |
+| `chain` | String | Chains enum value |
+| `signature` | String | indexed |
+| `message` | String | |
+| `createdAt` | Date | |
+| `updatedAt` | Date | |
+
+**Unique index:** `{ signature: 1, address: 1, chain: 1 }`
+
+---
+
+### `stateful_submit_swap_tx`
+**Writer:** stateful-api (creates), task-executor (updates status)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `txHash` | String | indexed |
+| `srcChainId` | String | SpokeChainId |
+| `walletAddress` | String | indexed |
+| `intent` | Object | same Intent shape |
+| `relayData` | String | hex-encoded |
+| `status` | String | SubmitSwapTxStatus, default: `"pending"` |
+| `failedAtStep` | String | optional |
+| `failureReason` | String | optional |
+| `failedAttempts` | Number | default: 0 |
+| `lastFailedAt` | Date | optional |
+| `result.dstIntentTxHash` | String | optional |
+| `result.packetData` | Object | optional |
+| `result.intent_hash` | String | optional, indexed |
+| `createdAt` | Date | |
+| `updatedAt` | Date | |
+
+**Indexes:**
+- `{ txHash: 1, srcChainId: 1 }` (unique)
+- `{ status: 1, failedAttempts: 1, lastFailedAt: 1, createdAt: 1 }`
+
+---
+
+### `stateful_partner_naming`
+**Writer:** stateful-api
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `walletAddress` | String | unique, lowercase, trimmed |
+| `name` | String | nullable, unique (sparse) |
+| `createdAt` | Date | |
+| `updatedAt` | Date | |
+
+---
+
+### `stateful_signature_attestations`
+**Writer:** stateful-api
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `address` | String | trimmed, lowercase |
+| `purpose` | String | trimmed |
+| `message` | String | |
+| `signature` | String | |
+| `createdAt` | Date | |
+| `updatedAt` | Date | |
+
+**Indexes:**
+- `{ address: 1, purpose: 1 }` (unique)
+- `{ createdAt: -1 }`
+
+---
+
+### `stateful_signature_challenges`
+**Writer:** stateful-api
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `walletAddress` | String | unique, lowercase, trimmed |
+| `challengesByPurpose` | Map | purpose → `{ nonce, generatedAt }` |
+| `createdAt` | Date | |
+| `updatedAt` | Date | |
+
+---
+
+## Other Collections
+
+### `portfolio_snapshots`
+**Writer:** task-executor
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `address` | String (Address) | |
+| `chainId` | Number | |
+| `blockNumber` | Number | |
+| `blockTimestamp` | Date | |
+| `tokenBalances` | Array | `{ tokenAddress, symbol, balance (Decimal128) }` |
+| `moneyMarketPositions` | Array | `{ reserveAddress, aTokenBalance, variableDebtTokenBalance }` |
+| `lpPositions` | Array | `{ tokenId, currency0, currency1, tickLower, tickUpper, liquidity }` |
+| `createdAt` | Date | |
+| `updatedAt` | Date | |
+
+**Indexes:**
+- `{ address: 1, chainId: 1, blockNumber: 1 }` (unique)
+- `{ address: 1, chainId: 1, blockTimestamp: 1 }`

--- a/docs/sodax-backend/DATA_FLOW.md
+++ b/docs/sodax-backend/DATA_FLOW.md
@@ -1,0 +1,97 @@
+# SODAX Backend — Data Flow & Collection Ownership
+
+## Architecture
+
+```
+Smart Contracts (Sonic chain, chainId 146/64165)
+         │
+         ▼
+┌─────────────────┐     ┌──────────────┐
+│ Data Aggregator  │────▶│   MongoDB    │◀──── Stateful API (user/partner data)
+│ (event listener) │     │              │◀──── Task Executor (portfolio snapshots)
+└─────────────────┘     └──────┬───────┘
+                               │
+                               ▼
+                  ┌─────────────────────┐
+                  │ Data Transformator   │──▶ MongoDB (transformed collections)
+                  │ (event processing)   │
+                  └─────────────────────┘
+                               │
+                               ▼
+                        ┌─────────┐
+                        │   API   │──▶ Redis cache ──▶ Frontend
+                        └─────────┘
+```
+
+## Write Ownership Table
+
+**Rule:** Each collection has exactly ONE writer service. Reads are unrestricted.
+
+| Collection | Writer | Notes |
+|------------|--------|-------|
+| **Raw Events** | | |
+| `intent_events` | data-aggregator | intents log aggregator |
+| `money_market_events` | data-aggregator | money-market log aggregator |
+| `amm_events` | data-aggregator | amm log aggregator |
+| `wallet_factory_events` | data-aggregator | wallet-factory log aggregator |
+| `protocol_revenue_events` | data-aggregator | protocol-revenue log aggregator |
+| `aggregator_events_metadata` | data-aggregator | tracks sync progress per contract |
+| `sodax_supply` | data-aggregator | sodax-supply data aggregator (singleton) |
+| **Transformed** | | |
+| `intent_journal` | data-transformator | |
+| `intent_journal_metadata` | data-transformator | singleton |
+| `orderbook` | data-transformator | |
+| `orderbook_metadata` | data-transformator | singleton |
+| `reserve_tokens` | data-transformator | |
+| `user_positions` | data-transformator | |
+| `money_market_events_metadata` | data-transformator | singleton |
+| `amm_candles` | data-transformator | |
+| `amm_tokens` | data-transformator | |
+| `amm_nft_positions` | data-transformator | |
+| `amm_events_metadata` | data-transformator | singleton |
+| `solver_volume` | data-transformator | |
+| `solver_volume_metadata` | data-transformator | singleton |
+| `partner_asset` | data-transformator | |
+| `protocol_revenue_events_metadata` | data-transformator | singleton |
+| **Stateful** | | |
+| `stateful_users` | stateful-api | |
+| `stateful_partner_naming` | stateful-api | |
+| `stateful_signature_attestations` | stateful-api | |
+| `stateful_signature_challenges` | stateful-api | |
+| `stateful_submit_swap_tx` | stateful-api + task-executor | **exception**: stateful-api creates, task-executor updates status |
+| **Other** | | |
+| `portfolio_snapshots` | task-executor | scheduled snapshots |
+
+## Key Domain Rules
+
+### Intent Identity
+- `intentId` is **NOT unique** — the same intentId can appear multiple times (e.g., after cancellation and re-creation).
+- Always use `intentHash` as the unique identifier for an intent.
+- The `intentHash` is derived from the intent data and is guaranteed unique.
+
+### Decimal128 / BigInt Handling
+- All blockchain quantities (amounts, balances, indexes) are stored as `Decimal128` in MongoDB.
+- The backend converts `BigInt ↔ Decimal128` via getters/setters on Mongoose schemas.
+- In Rust: deserialize `Decimal128` from BSON, then convert to `u128` or `U256`.
+- String fields like `sodax_supply.totalSupply` and `amm_candles.open/high/low/close` store numeric values as plain strings (not Decimal128).
+
+### Aave Scaled Balance Math
+- All aToken and debtToken balances in `user_positions` are **scaled balances** (not real balances).
+- To get real balance: `realBalance = scaledBalance × currentIndex / RAY`
+- `RAY = 10^27` (Aave's precision constant).
+- Current indexes are in `reserve_tokens.liquidityIndex` and `reserve_tokens.variableBorrowIndex`.
+
+### Event Discriminator Pattern
+Four event collections use Mongoose discriminators on the `eventType` field:
+- `intent_events` — 4 variants
+- `money_market_events` — 17 variants (11 with schemas, 6 aggregated but not deserialized by transformator)
+- `amm_events` — 4 variants
+- `protocol_revenue_events` — 3 variants
+
+Each variant adds different fields to the base event document. When querying, filter by `eventType` to know which fields are present.
+
+### Metadata / Singleton Pattern
+All `*_metadata` collections (except `aggregator_events_metadata`) use a single document with `_id: "singleton"`. They track the last processed block and a list of processed event keys (`"txHash-logIndex"` format) to enable idempotent reprocessing.
+
+### Collection Name Convention
+All MongoDB collection names use **snake_case** (e.g., `intent_events`, `user_positions`). This matches the `CollectionNames` enum in the backend.

--- a/docs/sodax-backend/ENUMS.md
+++ b/docs/sodax-backend/ENUMS.md
@@ -1,0 +1,223 @@
+# SODAX Backend — Enum Reference
+
+All enum/const values used across the backend. Use these for filtering queries and validating data.
+
+---
+
+## Event Type Enums
+
+### IntentEventType
+```
+intent-created
+intent-cancelled
+intent-filled
+external-fill-failed
+```
+
+### MoneyMarketEventType
+```
+borrow
+supply
+repay
+withdraw
+user-emode-set
+flash-loan
+isolation-mode-total-debt-updated
+liquidation-call
+mint-unbacked
+back-unbacked
+a-token-transfer
+a-token-balance-transfer
+a-token-burn
+a-token-mint
+debt-token-burn
+debt-token-mint
+reserve-data-updated
+```
+
+### AmmEventType
+```
+transfer
+mint-position
+swap
+initialize
+```
+
+### WalletFactoryEventType
+```
+deployed
+```
+
+### ProtocolRevenueEventType
+```
+minted-to-treasury
+fees-distributed-to-treasury
+fee-collected
+```
+
+---
+
+## Aggregator Enums
+
+### LogAggregator
+```
+intents
+money-market
+wallet-factory
+amm
+protocol-revenue
+```
+> Do not change existing values — only append.
+
+### DataAggregator
+```
+sodax-supply
+```
+
+Combined as `Aggregator = { ...LogAggregator, ...DataAggregator }`.
+
+---
+
+## Chain Enums
+
+### ChainId
+| Name | Value |
+|------|-------|
+| SONIC | `146` |
+| SONIC_TESTNET | `64165` |
+
+### ChainType
+```
+evm
+```
+
+### Chains (multi-chain signature support)
+```
+EVM
+STELLAR
+SUI
+SOLANA
+INJECTIVE
+```
+
+---
+
+## AMM Enums
+
+### AmmInterval
+```
+1m
+5m
+15m
+1h
+4h
+1d
+```
+
+---
+
+## Stateful Enums
+
+### SubmitSwapTxStatus (type union, not enum)
+```
+pending
+verifying
+verified
+relaying
+relayed
+posting_execution
+executed
+failed
+```
+
+Status flow: `pending → verifying → verified → relaying → relayed → posting_execution → executed`
+Any step can transition to `failed`.
+
+---
+
+## Incident Manager Enums
+
+### IncidentFlowTypes
+```
+MONEY_MARKET_CORRUPTED
+AMM_CORRUPTED
+INTENT_CREATED_EVENT_NOT_FOUND
+```
+
+### IncidentCodeTypes
+```
+INVARIANT_BROKEN
+DERIVED_MISMATCH
+SCHEMA_DRIFT
+```
+
+### IncidentStatuses
+```
+pending
+running
+resolved
+failed
+```
+
+### TargetStatuses
+```
+pending
+running
+done
+failed
+```
+
+---
+
+## Other Enums
+
+### EnvType
+```
+dev
+prod
+test
+```
+
+### LogLevel
+```
+debug
+info
+warn
+error
+```
+
+---
+
+## CollectionNames
+Complete mapping of enum key → MongoDB collection name:
+
+| Enum Key | Collection Name |
+|----------|----------------|
+| AGGREGATOR_EVENTS_METADATA | `aggregator_events_metadata` |
+| INTENT_EVENTS | `intent_events` |
+| WALLET_FACTORY_EVENTS | `wallet_factory_events` |
+| MONEY_MARKET_EVENTS | `money_market_events` |
+| AMM_EVENTS | `amm_events` |
+| INTENT_JOURNAL_METADATA | `intent_journal_metadata` |
+| INTENT_JOURNAL | `intent_journal` |
+| MONEY_MARKET_EVENTS_METADATA | `money_market_events_metadata` |
+| RESERVE_TOKENS | `reserve_tokens` |
+| USER_POSITIONS | `user_positions` |
+| AMM_EVENTS_METADATA | `amm_events_metadata` |
+| AMM_NFT_POSITIONS | `amm_nft_positions` |
+| AMM_CANDLES | `amm_candles` |
+| AMM_TOKENS | `amm_tokens` |
+| ORDERBOOK_METADATA | `orderbook_metadata` |
+| ORDERBOOK | `orderbook` |
+| SOLVER_VOLUME_METADATA | `solver_volume_metadata` |
+| SOLVER_VOLUME | `solver_volume` |
+| PARTNER_ASSET | `partner_asset` |
+| PROTOCOL_REVENUE_EVENTS | `protocol_revenue_events` |
+| PROTOCOL_REVENUE_EVENTS_METADATA | `protocol_revenue_events_metadata` |
+| SODAX_SUPPLY | `sodax_supply` |
+| STATEFUL_USERS | `stateful_users` |
+| STATEFUL_SUBMIT_SWAP_TX | `stateful_submit_swap_tx` |
+| PARTNERS | `stateful_partner_naming` |
+| SIGNATURE_ATTESTATIONS | `stateful_signature_attestations` |
+| SIGNATURE_CHALLENGES | `stateful_signature_challenges` |
+| PORTFOLIO_SNAPSHOTS | `portfolio_snapshots` |


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` with project instructions, build commands, architecture overview, and key patterns for Claude Code
- Add `docs/sodax-backend/` with detailed MongoDB data model reference:
  - `COLLECTIONS.md` — collection schemas, field types, indexes, discriminator patterns
  - `ENUMS.md` — all enum values (event types, chain IDs, statuses, intervals)
  - `DATA_FLOW.md` — architecture diagram, write ownership, domain rules

## Test plan
- [x] Verify documentation renders correctly on GitHub
- [x] Confirm no impact on build (`cargo check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)