### PR TITLE
fix: adapt to removed balance history fields (sodax-backend #433)

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -321,6 +321,7 @@ pub async fn find_token_events(
 
 pub async fn find_user_balance_events(
   user_address: &str,
+  reserve_address: &str,
   token_type: Option<&str>,
 ) -> Result<Vec<UserBalanceEventDocument>, mongodb::error::Error> {
   let collection: Collection<UserBalanceEventDocument> = get_db()
@@ -328,8 +329,9 @@ pub async fn find_user_balance_events(
     .database()
     .collection(get_collections_config().user_balance_events);
 
-  let regex = create_regex_for_address(user_address);
-  let mut filter = doc! { "userAddress": &regex };
+  let user_regex = create_regex_for_address(user_address);
+  let reserve_regex = create_regex_for_address(reserve_address);
+  let mut filter = doc! { "userAddress": &user_regex, "reserveAddress": &reserve_regex };
 
   if let Some(tt) = token_type {
     filter.insert("tokenType", tt);

--- a/src/db.rs
+++ b/src/db.rs
@@ -7,6 +7,7 @@ use crate::models::{
   SolverVolumeTimestampAndBlock,
   MoneyMarketEventDocument,
   UserAssetPositionDocument,
+  UserBalanceEventDocument,
   // IntentEventDocument
 };
 // For async iteration over cursor
@@ -314,6 +315,25 @@ pub async fn find_token_events(
       { "tokenAddress": &token_address_regex },
       { "reserve": &reserve_regex },
   ]};
+
+  collect_all_with_filter(collection, filter).await
+}
+
+pub async fn find_user_balance_events(
+  user_address: &str,
+  token_type: Option<&str>,
+) -> Result<Vec<UserBalanceEventDocument>, mongodb::error::Error> {
+  let collection: Collection<UserBalanceEventDocument> = get_db()
+    .await
+    .database()
+    .collection(get_collections_config().user_balance_events);
+
+  let regex = create_regex_for_address(user_address);
+  let mut filter = doc! { "userAddress": &regex };
+
+  if let Some(tt) = token_type {
+    filter.insert("tokenType", tt);
+  }
 
   collect_all_with_filter(collection, filter).await
 }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -408,7 +408,7 @@ pub async fn handle_inspect_user_position(flags: Vec<Flag>) {
 
   // Query user_balance_events collection for this user and token type
   let token_type_str = if is_a_token { "aToken" } else { "variableDebtToken" };
-  let balance_events = match find_user_balance_events(&user_address, Some(token_type_str)).await {
+  let balance_events = match find_user_balance_events(&user_address, &position.reserveAddress, Some(token_type_str)).await {
     Ok(events) => events,
     Err(e) => {
       eprintln!("Error fetching user balance events: {}", e);

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -13,6 +13,7 @@ use crate::db::{
   find_user_events,
   find_token_events,
   find_user_assets_position,
+  find_user_balance_events,
 };
 use crate::evm::{
   get_last_block, get_balance_of, get_block_timestamp, get_atoken_liquidity_index,
@@ -405,16 +406,29 @@ pub async fn handle_inspect_user_position(flags: Vec<Flag>) {
     }
   };
 
-  // Extract eventIds from balance history based on token type
-  let mut balance_history_event_ids = std::collections::HashSet::new();
+  // Query user_balance_events collection for this user and token type
+  let token_type_str = if is_a_token { "aToken" } else { "variableDebtToken" };
+  let balance_events = match find_user_balance_events(&user_address, Some(token_type_str)).await {
+    Ok(events) => events,
+    Err(e) => {
+      eprintln!("Error fetching user balance events: {}", e);
+      std::process::exit(1);
+    }
+  };
 
-  let balance_history = if is_a_token {
+  // Build set of eventIds from balance events collection
+  let mut balance_history_event_ids = std::collections::HashSet::new();
+  for event in &balance_events {
+    balance_history_event_ids.insert(event.eventId.clone());
+  }
+
+  // Also include any legacy embedded eventIds (for old documents pre-migration)
+  let legacy_balance_history = if is_a_token {
     &position.aTokenBalanceHistory
   } else {
     &position.debtTokenBalanceHistory
   };
-
-  for entry in balance_history {
+  for entry in legacy_balance_history {
     balance_history_event_ids.insert(entry.eventId.clone());
   }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -30,7 +30,9 @@ pub struct UserAssetPositionDocument {
   pub variableDebtTokenAddress: String,
   pub aTokenBalance: Decimal128,
   pub variableDebtTokenBalance: Decimal128,
+  #[serde(default)]
   pub debtTokenBalanceHistory: Vec<AssetBalanceEntryDocument>,
+  #[serde(default)]
   pub aTokenBalanceHistory: Vec<AssetBalanceEntryDocument>,
 }
 
@@ -41,6 +43,21 @@ pub struct AssetBalanceEntryDocument {
   #[serde(rename = "final")]
   pub r#final: Decimal128,
   pub delta: Decimal128,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[allow(non_snake_case)]
+pub struct UserBalanceEventDocument {
+  #[serde(rename = "_id")]
+  pub id: ObjectId,
+  pub eventId: String,
+  pub userAddress: String,
+  pub reserveAddress: String,
+  pub tokenType: String,
+  pub scaledDelta: Decimal128,
+  pub blockNumber: u64,
+  pub txHash: String,
+  pub logIndex: i64,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -127,6 +127,7 @@ pub struct Collections {
   pub intent_events: &'static str,
   pub eventlog_progress_metadata: &'static str,
   pub solver_volume: &'static str,
+  pub user_balance_events: &'static str,
 }
 
 impl Default for Collections {
@@ -148,6 +149,7 @@ impl Collections {
       intent_events: "intentEvents",
       eventlog_progress_metadata: "event_log_progress_metadata",
       solver_volume: "solver_volume",
+      user_balance_events: "user_balance_events",
     }
   }
 }


### PR DESCRIPTION
## Summary

- Fixes deserialization crash caused by `sodax-backend` PR #433 removing `aTokenBalanceHistory` and `debtTokenBalanceHistory` embedded arrays from `user_positions` documents
- Makes the removed fields optional via `#[serde(default)]` so they deserialize as empty `Vec`s when missing
- Adds `UserBalanceEventDocument` model and `find_user_balance_events()` query for the new `user_balance_events` collection
- Updates `--inspect-user-position` handler to query `user_balance_events` while retaining backward compatibility with legacy embedded arrays

## Test plan

- [ ] `cargo build` compiles successfully
- [ ] Run any command that reads user positions (e.g. `--validate-all-users`) — should no longer crash with `missing field 'debtTokenBalanceHistory'`
- [ ] Run `--inspect-user-position <addr> --a-token <addr>` — should query `user_balance_events` and produce correct output

🤖 Generated with [Claude Code](https://claude.com/claude-code)