### PR TITLE
fix: query on-chain balances at DB block height, not latest block

### DIFF
--- a/src/evm.rs
+++ b/src/evm.rs
@@ -95,11 +95,18 @@ pub async fn get_scaled_balance_of(
   }
 }
 
-pub async fn get_total_supply(token_address: &str) -> Result<u128, Box<dyn std::error::Error>> {
-  let provider = get_provider().await.unwrap();
+pub async fn get_total_supply(
+  token_address: &str,
+  block_number: Option<u64>,
+) -> Result<u128, Box<dyn std::error::Error>> {
+  let provider = get_provider().await?;
   let token_address = token_address.parse::<Address>()?;
   let contract = A_TOKEN::new(token_address, provider);
-  match contract.totalSupply().call().await {
+  let mut call = contract.totalSupply();
+  if let Some(block) = block_number {
+    call = call.block(block.into());
+  }
+  match call.call().await {
     Ok(total_supply) => Ok(u128::try_from(total_supply).unwrap_or(0)),
     Err(e) => Err(Box::new(e)),
   }
@@ -107,11 +114,16 @@ pub async fn get_total_supply(token_address: &str) -> Result<u128, Box<dyn std::
 
 pub async fn get_scaled_total_supply(
   token_address: &str,
+  block_number: Option<u64>,
 ) -> Result<u128, Box<dyn std::error::Error>> {
-  let provider = get_provider().await.unwrap();
+  let provider = get_provider().await?;
   let token_address = token_address.parse::<Address>()?;
   let contract = A_TOKEN::new(token_address, provider);
-  match contract.scaledTotalSupply().call().await {
+  let mut call = contract.scaledTotalSupply();
+  if let Some(block) = block_number {
+    call = call.block(block.into());
+  }
+  match call.call().await {
     Ok(total_supply) => Ok(u128::try_from(total_supply).unwrap_or(0)),
     Err(e) => Err(Box::new(e)),
   }

--- a/src/validators.rs
+++ b/src/validators.rs
@@ -31,7 +31,7 @@ pub async fn validate_user_supply_amount(
     .ok_or("No reserve data found for the specified reserve address")?;
 
   let a_token_address = token_data.aTokenAddress;
-  let on_chain_amount = get_balance_of(&a_token_address, user_address, None).await?;
+  let on_chain_amount = get_balance_of(&a_token_address, user_address, Some(token_data.blockNumber)).await?;
 
   let result = EntryState::new(calculated_amount, on_chain_amount);
   Ok(result)
@@ -62,7 +62,7 @@ pub async fn validate_user_scaled_supply_amount(
     .ok_or("No reserve data found for the specified reserve address")?;
 
   let a_token_address = token_data.aTokenAddress;
-  let on_chain_amount = get_scaled_balance_of(&a_token_address, user_address, None).await?;
+  let on_chain_amount = get_scaled_balance_of(&a_token_address, user_address, Some(token_data.blockNumber)).await?;
 
   let result = EntryState::new(scaled_amount, on_chain_amount);
   Ok(result)
@@ -80,7 +80,7 @@ pub async fn validate_user_borrow_amount(
 
   let variable_debt_token_address = token_data.variableDebtTokenAddress;
 
-  let on_chain_amount = get_balance_of(&variable_debt_token_address, user_address, None).await?;
+  let on_chain_amount = get_balance_of(&variable_debt_token_address, user_address, Some(token_data.blockNumber)).await?;
 
   let result = EntryState::new(calculated_amount, on_chain_amount);
   Ok(result)
@@ -113,7 +113,7 @@ pub async fn validate_user_scaled_borrow_amount(
 
   let variable_debt_token_address = token_data.variableDebtTokenAddress;
 
-  let on_chain_amount = get_scaled_balance_of(&variable_debt_token_address, user_address, None).await?;
+  let on_chain_amount = get_scaled_balance_of(&variable_debt_token_address, user_address, Some(token_data.blockNumber)).await?;
 
   let result = EntryState::new(scaled_amount, on_chain_amount);
   Ok(result)
@@ -130,7 +130,7 @@ pub async fn validate_token_scaled_supply_amount(
     .await?
     .ok_or("No reserve data found for the specified reserve address")?;
   let a_token_address = token_data.aTokenAddress;
-  let on_chain_amount = get_scaled_total_supply(&a_token_address).await?;
+  let on_chain_amount = get_scaled_total_supply(&a_token_address, Some(token_data.blockNumber)).await?;
 
   let result = EntryState::new(calculated_amount, on_chain_amount);
   Ok(result)
@@ -146,7 +146,7 @@ pub async fn validate_token_supply_amount(
     .await?
     .ok_or("No reserve data found for the specified reserve address")?;
   let a_token_address = token_data.aTokenAddress;
-  let on_chain_amount = get_total_supply(&a_token_address).await?;
+  let on_chain_amount = get_total_supply(&a_token_address, Some(token_data.blockNumber)).await?;
 
   let result = EntryState::new(calculated_amount, on_chain_amount);
   Ok(result)
@@ -163,7 +163,7 @@ pub async fn validate_token_scaled_borrow_amount(
     .await?
     .ok_or("No reserve data found for the specified reserve address")?;
   let v_token_address = token_data.variableDebtTokenAddress;
-  let on_chain_amount = get_scaled_total_supply(&v_token_address).await?;
+  let on_chain_amount = get_scaled_total_supply(&v_token_address, Some(token_data.blockNumber)).await?;
 
   let result = EntryState::new(calculated_amount, on_chain_amount);
   Ok(result)
@@ -180,7 +180,7 @@ pub async fn validate_token_borrow_amount(
     .await?
     .ok_or("No reserve data found for the specified reserve address")?;
   let v_token_address = token_data.variableDebtTokenAddress;
-  let on_chain_amount = get_total_supply(&v_token_address).await?;
+  let on_chain_amount = get_total_supply(&v_token_address, Some(token_data.blockNumber)).await?;
 
   let result = EntryState::new(calculated_amount, on_chain_amount);
   Ok(result)


### PR DESCRIPTION
## Summary

- Validation commands (`--validate-all`, `--validate-users-all`, etc.) now query on-chain state at the **exact block the transformator last processed** (`reserve_tokens.blockNumber`), instead of the latest block
- This eliminates false discrepancies caused by events processed on-chain but not yet in the DB

## Problem

When running `--validate-all`, the tool compared DB snapshots against on-chain balances at the **latest block**. Any event processed on-chain between the DB's last update and the query would show as a discrepancy. For example, a 3.17% supply mismatch on reserve `0x21685e...` was likely just a recent large deposit that the transformator hadn't processed yet.

## Changes

| File | What |
|------|------|
| `src/evm.rs` | `get_total_supply()` and `get_scaled_total_supply()` now accept optional `block_number` parameter |
| `src/validators.rs` | All 8 validator functions pass `token_data.blockNumber` to on-chain calls |

## Test plan

- [ ] Run `--validate-all` and confirm the 3.17% supply discrepancy on `0x21685e...` disappears (if it was a timing issue)
- [ ] All other diffs should shrink to near-zero (no more interest accrual drift)
- [ ] Any remaining discrepancy is a real transformator bug, not a race condition

🤖 Generated with [Claude Code](https://claude.com/claude-code)