### PR TITLE
feat: add --validate-partner-asset command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ target
 # Reports
 report.txt
 reports/
+
+# Scratch (local-only notes, specs, drafts)
+scratch/

--- a/docs/sodax-backend/COLLECTIONS.md
+++ b/docs/sodax-backend/COLLECTIONS.md
@@ -440,10 +440,10 @@ No additional fields.
 | `asset` | String (Address) | |
 | `chainId` | Number | |
 | `lastBlockNumber` | Number | |
-| `outputs` | Map | keyed by solver address |
-| `outputs.<solver>.totalVolumeOut` | Decimal128 | |
-| `outputs.<solver>.totalFeeIn` | Decimal128 | |
-| `outputs.<solver>.txCount` | Number | |
+| `outputs` | Map | keyed by output token address |
+| `outputs.<outputToken>.totalVolumeOut` | Decimal128 | |
+| `outputs.<outputToken>.totalFeeIn` | Decimal128 | |
+| `outputs.<outputToken>.txCount` | Number | |
 | `createdAt` | Date | |
 | `updatedAt` | Date | |
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -202,6 +202,32 @@ pub fn parse_args() -> Result<Vec<Flag>, Box<dyn std::error::Error>> {
         flags.push(Flag::InspectUserPosition(args[i + 1].clone()));
         consumed_next_arg = true;
       }
+      "--validate-partner-asset" => {
+        validate_flag_does_not_accept_argument(i, &args)?;
+        flags.push(Flag::ValidatePartnerAsset);
+      }
+      "--partner" => {
+        validate_flag_accepts_argument(i, args.len())?;
+        validate_next_argument_is_not_flag(i, &args)?;
+        flags.push(Flag::Partner(args[i + 1].clone()));
+        consumed_next_arg = true;
+      }
+      "--json" => {
+        validate_flag_does_not_accept_argument(i, &args)?;
+        flags.push(Flag::Json);
+      }
+      "--threshold" => {
+        validate_flag_accepts_argument(i, args.len())?;
+        validate_next_argument_is_not_flag(i, &args)?;
+        let threshold = args[i + 1].parse::<f64>().map_err(|_| {
+          format!(
+            "Invalid threshold: {}. Must be a valid floating-point number.",
+            args[i + 1]
+          )
+        })?;
+        flags.push(Flag::Threshold(threshold));
+        consumed_next_arg = true;
+      }
       _ => return Err(format!("Unknown argument: {}", arg).into()),
     }
     // Move to the next argument
@@ -364,6 +390,33 @@ pub fn parse_args() -> Result<Vec<Flag>, Box<dyn std::error::Error>> {
     if !allowed_companions {
       return Err("--validate-from-events can only be combined with --reserve-token. Use --help for more information.".into());
     }
+  }
+
+  // --validate-partner-asset can be combined with --partner, --json, --threshold (all optional)
+  let has_validate_partner_asset = flags
+    .iter()
+    .any(|flag| matches!(flag, Flag::ValidatePartnerAsset));
+  if has_validate_partner_asset {
+    let allowed_companions = flags.iter().all(|flag| {
+      matches!(
+        flag,
+        Flag::ValidatePartnerAsset | Flag::Partner(_) | Flag::Json | Flag::Threshold(_)
+      )
+    });
+    if !allowed_companions {
+      return Err("--validate-partner-asset can only be combined with --partner, --json, --threshold. Use --help for more information.".into());
+    }
+  }
+
+  // --partner, --json and --threshold are only valid alongside --validate-partner-asset
+  let has_partner_companion = flags.iter().any(|flag| {
+    matches!(
+      flag,
+      Flag::Partner(_) | Flag::Json | Flag::Threshold(_)
+    )
+  });
+  if has_partner_companion && !has_validate_partner_asset {
+    return Err("--partner, --json and --threshold can only be used with --validate-partner-asset.".into());
   }
 
   // the following flags need to be used acompanied by

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -46,6 +46,10 @@ BULK VALIDATION OPTIONS:
     --validate-all-reserve-indexes       Validate indexes for all reserves
     --validate-from-events <USER_ADDRESS> Validate user positions by replaying raw events (3-way: events vs DB vs on-chain)
     --validate-from-events-all           Validate all users by replaying raw events
+    --validate-partner-asset             Recompute partner_asset aggregates from solver_volume and report drift
+    --partner <ADDRESS>                  Optional: limit --validate-partner-asset to a single receiver address
+    --json                               Optional: emit --validate-partner-asset output as JSON
+    --threshold <PCT>                    Optional: rows within ±PCT of 1.0 are suppressed from the --validate-partner-asset table (default 0.0001)
 
 SCALED VALIDATION:
     The --scaled flag can be combined with validation flags to compare scaled balances instead of real balances:
@@ -120,6 +124,12 @@ EXAMPLES:
     sodax-backend-analizer --validate-from-events 0xuser123...
     sodax-backend-analizer --validate-from-events 0xuser123... --reserve-token 0xtoken456...
     sodax-backend-analizer --validate-from-events-all
+
+    # Partner asset drift validation (recompute from solver_volume)
+    sodax-backend-analizer --validate-partner-asset
+    sodax-backend-analizer --validate-partner-asset --partner 0xpartner123...
+    sodax-backend-analizer --validate-partner-asset --threshold 0
+    sodax-backend-analizer --validate-partner-asset --json
 
 REPORT FILES:
     By default, every command (except --help) saves its output to a report file

--- a/src/db.rs
+++ b/src/db.rs
@@ -8,6 +8,7 @@ use crate::models::{
   MoneyMarketEventDocument,
   UserAssetPositionDocument,
   UserBalanceEventDocument,
+  PartnerAssetDocument,
   // IntentEventDocument
 };
 // For async iteration over cursor
@@ -92,6 +93,28 @@ pub async fn get_solver_volume() -> Result<Vec<SolverVolumeDocument>, mongodb::e
     .collection(get_collections_config().solver_volume);
   let docs: Vec<SolverVolumeDocument> = collect_all(collection).await?;
   Ok(docs)
+}
+
+pub async fn get_partner_asset() -> Result<Vec<PartnerAssetDocument>, mongodb::error::Error> {
+  let collection: Collection<PartnerAssetDocument> = get_db()
+    .await
+    .database()
+    .collection(get_collections_config().partner_asset);
+  let docs: Vec<PartnerAssetDocument> = collect_all(collection).await?;
+  Ok(docs)
+}
+
+pub async fn find_partner_asset_for_receiver(
+  receiver: &str,
+) -> Result<Vec<PartnerAssetDocument>, mongodb::error::Error> {
+  let collection: Collection<PartnerAssetDocument> = get_db()
+    .await
+    .database()
+    .collection(get_collections_config().partner_asset);
+
+  let regex = create_regex_for_address(receiver);
+  let filter = doc! { "receiver": &regex };
+  collect_all_with_filter(collection, filter).await
 }
 
 pub async fn find_docs_with_non_null_timestamp()

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -28,6 +28,7 @@ pub fn extract_optional_value_from_flags(flags: &[Flag], flag_type: FlagType) ->
     (Flag::ValidateTimestamps(value_opt), FlagType::ValidateTimestamps) => value_opt.clone(),
     (Flag::InspectUserPosition(value), FlagType::InspectUserPosition) => Some(value.clone()),
     (Flag::ValidateFromEvents(value), FlagType::ValidateFromEvents) => Some(value.clone()),
+    (Flag::Partner(value), FlagType::Partner) => Some(value.clone()),
     _ => None,
   })
 }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -16,6 +16,8 @@ use crate::db::{
   find_user_assets_position,
   get_user_position,
   find_user_balance_events,
+  get_partner_asset,
+  find_partner_asset_for_receiver,
 };
 use crate::evm::{
   get_last_block, get_balance_of, get_block_timestamp, get_atoken_liquidity_index,
@@ -33,7 +35,11 @@ use crate::functions::{
   extract_value_from_flags_or_exit, extract_optional_value_from_flags, decimal128_to_u128,
 };
 use crate::structs::{ReserveTokenField, Flag, FlagType, ThreeWayComparison, EventValidationResult};
-use crate::models::{ReserveTokenDocument, SolverVolumeDocument, MoneyMarketEventDocument};
+use crate::models::{
+  ReserveTokenDocument, SolverVolumeDocument, MoneyMarketEventDocument, PartnerAssetDocument,
+  PartnerOutput,
+};
+use crate::intent_data_decoder::{extract_fee_from_intent_data, FeeIntentData};
 use crate::constants::HELP_MESSAGE;
 use futures::future::join_all;
 use tokio::task;
@@ -2102,6 +2108,461 @@ fn print_three_way(
     "  Events vs DB:    {} ({:.4}%)",
     comparison.events_vs_db_diff, comparison.events_vs_db_pct
   );
+}
+
+// ============================================================================
+// --validate-partner-asset
+// ============================================================================
+//
+// Recomputes the canonical `partner_asset` aggregate from `solver_volume`
+// (which is correct, unique-indexed) and reports per-row drift against the
+// stored values. Used to verify the data-transformator `$inc`-bug from
+// sodax-backend issue #498.
+
+const DEFAULT_PARTNER_ASSET_THRESHOLD: f64 = 0.0001;
+
+#[derive(Debug, Clone)]
+struct OutputTotals {
+  total_fee_in: alloy::primitives::U256,
+  total_volume_out: alloy::primitives::U256,
+  tx_count: u64,
+}
+
+impl OutputTotals {
+  fn new() -> Self {
+    Self {
+      total_fee_in: alloy::primitives::U256::ZERO,
+      total_volume_out: alloy::primitives::U256::ZERO,
+      tx_count: 0,
+    }
+  }
+}
+
+#[derive(Debug, Clone)]
+struct DriftRow {
+  receiver: String,
+  asset: String,
+  chain_id: u64,
+  output_token: String,
+  stored_cnt: u64,
+  computed_cnt: u64,
+  stored_fee: String,
+  computed_fee: String,
+  stored_vol: String,
+  computed_vol: String,
+  cnt_ratio: Option<f64>,
+  fee_ratio: Option<f64>,
+  vol_ratio: Option<f64>,
+  status: &'static str,
+}
+
+fn decimal128_to_u256(d: &mongodb::bson::Decimal128) -> Option<alloy::primitives::U256> {
+  alloy::primitives::U256::from_str_radix(&d.to_string(), 10).ok()
+}
+
+fn u256_to_f64(value: &alloy::primitives::U256) -> f64 {
+  value.to_string().parse::<f64>().unwrap_or(0.0)
+}
+
+fn safe_ratio(stored: f64, computed: f64) -> Option<f64> {
+  if computed == 0.0 {
+    None
+  } else {
+    Some(stored / computed)
+  }
+}
+
+fn ratio_within(ratio: Option<f64>, threshold: f64) -> bool {
+  match ratio {
+    Some(r) => (r - 1.0).abs() <= threshold,
+    None => false,
+  }
+}
+
+pub async fn handle_validate_partner_asset(flags: Vec<Flag>) {
+  let partner_filter = extract_optional_value_from_flags(&flags, FlagType::Partner)
+    .map(|p| p.to_lowercase());
+  let output_json = flags.iter().any(|f| matches!(f, Flag::Json));
+  let threshold = flags
+    .iter()
+    .find_map(|f| match f {
+      Flag::Threshold(t) => Some(*t),
+      _ => None,
+    })
+    .unwrap_or(DEFAULT_PARTNER_ASSET_THRESHOLD);
+
+  if !output_json {
+    output!("\n=== Partner Asset Validation ===");
+    if let Some(ref p) = partner_filter {
+      output!("Partner filter: {}", p);
+    }
+    output!("Threshold: {} (rows within ±{}% are suppressed from table)", threshold, threshold * 100.0);
+  }
+
+  // 1. Load solver_volume (authoritative source) and sort by (blockNumber, logIndex)
+  //    so that any future $max-style accumulation matches the stored convention.
+  let mut solver_rows = match get_solver_volume().await {
+    Ok(rows) => rows,
+    Err(e) => {
+      eprintln!("Error fetching solver_volume: {}", e);
+      std::process::exit(1);
+    }
+  };
+  solver_rows.sort_by_key(|r: &SolverVolumeDocument| (r.blockNumber, r.logIndex));
+
+  if !output_json {
+    output!("Loaded {} solver_volume rows.", solver_rows.len());
+  }
+
+  // 2. Decode + aggregate.
+  type Key = (String, String, u64);
+  let mut computed: std::collections::HashMap<
+    Key,
+    std::collections::HashMap<String, OutputTotals>,
+  > = std::collections::HashMap::new();
+  let mut last_block: std::collections::HashMap<Key, u64> = std::collections::HashMap::new();
+  let mut rows_skipped_no_fee: u64 = 0;
+  let mut rows_skipped_filter: u64 = 0;
+  let mut rows_aggregated: u64 = 0;
+
+  for row in &solver_rows {
+    let Some(FeeIntentData { fee, receiver }) = extract_fee_from_intent_data(&row.data) else {
+      rows_skipped_no_fee += 1;
+      continue;
+    };
+    let receiver_lower = format!("{:#x}", receiver);
+    if let Some(ref pf) = partner_filter
+      && &receiver_lower != pf
+    {
+      rows_skipped_filter += 1;
+      continue;
+    }
+    let asset_lower = row.inputToken.to_lowercase();
+    let output_lower = row.outputToken.to_lowercase();
+    let key: Key = (receiver_lower, asset_lower, row.chainId);
+
+    let amount = match decimal128_to_u256(&row.amount) {
+      Some(a) => a,
+      None => {
+        eprintln!(
+          "Warning: could not parse amount {} as U256 (tx {}); skipping row.",
+          row.amount, row.txHash
+        );
+        continue;
+      }
+    };
+
+    let bucket = computed
+      .entry(key.clone())
+      .or_default()
+      .entry(output_lower)
+      .or_insert_with(OutputTotals::new);
+    bucket.total_fee_in += fee;
+    bucket.total_volume_out += amount;
+    bucket.tx_count += 1;
+
+    let block_entry = last_block.entry(key).or_insert(0);
+    if row.blockNumber > *block_entry {
+      *block_entry = row.blockNumber;
+    }
+    rows_aggregated += 1;
+  }
+
+  if !output_json {
+    output!(
+      "Aggregated {} rows; skipped {} without fee data; {} filtered out by --partner.",
+      rows_aggregated, rows_skipped_no_fee, rows_skipped_filter
+    );
+  }
+
+  // 3. Load partner_asset stored docs.
+  let stored_docs: Vec<PartnerAssetDocument> = match &partner_filter {
+    Some(p) => match find_partner_asset_for_receiver(p).await {
+      Ok(d) => d,
+      Err(e) => {
+        eprintln!("Error fetching partner_asset for receiver {}: {}", p, e);
+        std::process::exit(1);
+      }
+    },
+    None => match get_partner_asset().await {
+      Ok(d) => d,
+      Err(e) => {
+        eprintln!("Error fetching partner_asset: {}", e);
+        std::process::exit(1);
+      }
+    },
+  };
+
+  // Index stored docs by (receiver_lower, asset_lower, chainId) for O(1) lookup.
+  let mut stored: std::collections::HashMap<Key, &PartnerAssetDocument> =
+    std::collections::HashMap::new();
+  for d in &stored_docs {
+    let key: Key = (d.receiver.to_lowercase(), d.asset.to_lowercase(), d.chainId);
+    stored.insert(key, d);
+  }
+
+  // 4. Build the set of all keys to report on (union of computed + stored).
+  let mut all_keys: std::collections::HashSet<Key> = std::collections::HashSet::new();
+  for k in computed.keys() {
+    all_keys.insert(k.clone());
+  }
+  for k in stored.keys() {
+    all_keys.insert(k.clone());
+  }
+
+  // 5. Per (receiver, asset, chainId) × outputToken row build comparison drift entries.
+  let mut drift_rows: Vec<DriftRow> = Vec::new();
+  for key in &all_keys {
+    let empty_outputs: std::collections::HashMap<String, PartnerOutput> =
+      std::collections::HashMap::new();
+    let stored_outputs = stored
+      .get(key)
+      .map(|d| &d.outputs)
+      .unwrap_or(&empty_outputs);
+    let empty_computed: std::collections::HashMap<String, OutputTotals> =
+      std::collections::HashMap::new();
+    let computed_outputs = computed.get(key).unwrap_or(&empty_computed);
+
+    let mut output_tokens: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for ot in stored_outputs.keys() {
+      output_tokens.insert(ot.to_lowercase());
+    }
+    for ot in computed_outputs.keys() {
+      output_tokens.insert(ot.clone());
+    }
+
+    for output_token in &output_tokens {
+      // Stored outputs may be keyed by mixed-case token addresses; do a case-insensitive lookup.
+      let stored_entry = stored_outputs
+        .iter()
+        .find(|(k, _)| k.to_lowercase() == *output_token)
+        .map(|(_, v)| v);
+      let computed_entry = computed_outputs.get(output_token);
+
+      let stored_cnt = stored_entry.map(|s| s.txCount as u64).unwrap_or(0);
+      let computed_cnt = computed_entry.map(|c| c.tx_count).unwrap_or(0);
+
+      let stored_fee_str = stored_entry
+        .map(|s| s.totalFeeIn.to_string())
+        .unwrap_or_else(|| "0".to_string());
+      let computed_fee_str = computed_entry
+        .map(|c| c.total_fee_in.to_string())
+        .unwrap_or_else(|| "0".to_string());
+      let stored_vol_str = stored_entry
+        .map(|s| s.totalVolumeOut.to_string())
+        .unwrap_or_else(|| "0".to_string());
+      let computed_vol_str = computed_entry
+        .map(|c| c.total_volume_out.to_string())
+        .unwrap_or_else(|| "0".to_string());
+
+      let stored_fee_f = stored_fee_str.parse::<f64>().unwrap_or(0.0);
+      let computed_fee_f = computed_entry
+        .map(|c| u256_to_f64(&c.total_fee_in))
+        .unwrap_or(0.0);
+      let stored_vol_f = stored_vol_str.parse::<f64>().unwrap_or(0.0);
+      let computed_vol_f = computed_entry
+        .map(|c| u256_to_f64(&c.total_volume_out))
+        .unwrap_or(0.0);
+
+      let cnt_ratio = safe_ratio(stored_cnt as f64, computed_cnt as f64);
+      let fee_ratio = safe_ratio(stored_fee_f, computed_fee_f);
+      let vol_ratio = safe_ratio(stored_vol_f, computed_vol_f);
+
+      let status = if computed_cnt > 0 && stored_cnt == 0 {
+        "MISSING_IN_STORED"
+      } else if stored_cnt > 0 && computed_cnt == 0 {
+        "EXTRA_IN_STORED"
+      } else if ratio_within(cnt_ratio, threshold)
+        && ratio_within(fee_ratio, threshold)
+        && ratio_within(vol_ratio, threshold)
+      {
+        "OK"
+      } else {
+        "DRIFT"
+      };
+
+      drift_rows.push(DriftRow {
+        receiver: key.0.clone(),
+        asset: key.1.clone(),
+        chain_id: key.2,
+        output_token: output_token.clone(),
+        stored_cnt,
+        computed_cnt,
+        stored_fee: stored_fee_str,
+        computed_fee: computed_fee_str,
+        stored_vol: stored_vol_str,
+        computed_vol: computed_vol_str,
+        cnt_ratio,
+        fee_ratio,
+        vol_ratio,
+        status,
+      });
+    }
+  }
+
+  // Stable ordering for output.
+  drift_rows.sort_by(|a, b| {
+    a.receiver
+      .cmp(&b.receiver)
+      .then(a.asset.cmp(&b.asset))
+      .then(a.chain_id.cmp(&b.chain_id))
+      .then(a.output_token.cmp(&b.output_token))
+  });
+
+  // 6. Summary metrics.
+  let total_rows = drift_rows.len();
+  let rows_ok = drift_rows.iter().filter(|r| r.status == "OK").count();
+  let rows_drift = drift_rows.iter().filter(|r| r.status == "DRIFT").count();
+  let rows_missing = drift_rows
+    .iter()
+    .filter(|r| r.status == "MISSING_IN_STORED")
+    .count();
+  let rows_extra = drift_rows
+    .iter()
+    .filter(|r| r.status == "EXTRA_IN_STORED")
+    .count();
+  let rows_over = drift_rows
+    .iter()
+    .filter(|r| {
+      r.cnt_ratio.map(|x| x > 1.0 + threshold).unwrap_or(false)
+        || r.fee_ratio.map(|x| x > 1.0 + threshold).unwrap_or(false)
+        || r.vol_ratio.map(|x| x > 1.0 + threshold).unwrap_or(false)
+    })
+    .count();
+  let rows_under = drift_rows
+    .iter()
+    .filter(|r| {
+      r.cnt_ratio.map(|x| x < 1.0 - threshold).unwrap_or(false)
+        || r.fee_ratio.map(|x| x < 1.0 - threshold).unwrap_or(false)
+        || r.vol_ratio.map(|x| x < 1.0 - threshold).unwrap_or(false)
+    })
+    .count();
+
+  let cnt_ratios: Vec<f64> = drift_rows.iter().filter_map(|r| r.cnt_ratio).collect();
+  let max_cnt_ratio = cnt_ratios
+    .iter()
+    .cloned()
+    .fold(f64::NEG_INFINITY, f64::max);
+  let min_cnt_ratio = cnt_ratios.iter().cloned().fold(f64::INFINITY, f64::min);
+  let unique_cnt_ratios = {
+    let mut buckets: Vec<f64> = Vec::new();
+    for r in &cnt_ratios {
+      let rounded = (r * 1000.0).round() / 1000.0;
+      if !buckets.iter().any(|b| (b - rounded).abs() < 1e-9) {
+        buckets.push(rounded);
+      }
+    }
+    buckets.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    buckets
+  };
+
+  if output_json {
+    let rows_json: Vec<_> = drift_rows
+      .iter()
+      .map(|r| {
+        serde_json::json!({
+          "receiver": r.receiver,
+          "asset": r.asset,
+          "chainId": r.chain_id,
+          "outputToken": r.output_token,
+          "storedCnt": r.stored_cnt,
+          "computedCnt": r.computed_cnt,
+          "storedFee": r.stored_fee,
+          "computedFee": r.computed_fee,
+          "storedVol": r.stored_vol,
+          "computedVol": r.computed_vol,
+          "cntRatio": r.cnt_ratio,
+          "feeRatio": r.fee_ratio,
+          "volRatio": r.vol_ratio,
+          "status": r.status,
+        })
+      })
+      .collect();
+
+    let summary = serde_json::json!({
+      "partnerAssetDocs": stored_docs.len(),
+      "computedKeys": computed.len(),
+      "rowsTotal": total_rows,
+      "rowsAgreeingWithinThreshold": rows_ok,
+      "rowsWithDrift": rows_drift,
+      "rowsMissingInStored": rows_missing,
+      "rowsExtraInStored": rows_extra,
+      "rowsOverCountedByStored": rows_over,
+      "rowsUnderCountedByStored": rows_under,
+      "maxCntRatio": if cnt_ratios.is_empty() { None } else { Some(max_cnt_ratio) },
+      "minCntRatio": if cnt_ratios.is_empty() { None } else { Some(min_cnt_ratio) },
+      "uniqueCntRatios": unique_cnt_ratios,
+      "solverVolumeRowsAggregated": rows_aggregated,
+      "solverVolumeRowsSkippedNoFee": rows_skipped_no_fee,
+      "solverVolumeRowsSkippedFilter": rows_skipped_filter,
+      "threshold": threshold,
+    });
+    let out = serde_json::json!({
+      "summary": summary,
+      "rows": rows_json,
+    });
+    output!("{}", serde_json::to_string_pretty(&out).unwrap());
+    return;
+  }
+
+  // 7. Human-readable table.
+  output!(
+    "\n{:<44} {:<44} {:<11} {:<44} {:<10} {:<12} {:<9} {:<9} {:<9} {}",
+    "RECEIVER", "ASSET", "CHAIN", "OUTPUT_TOKEN", "STORED_CNT", "COMPUTED_CNT",
+    "CNT_RATIO", "FEE_RATIO", "VOL_RATIO", "STATUS"
+  );
+  let mut printed_rows = 0;
+  for r in &drift_rows {
+    if r.status == "OK" {
+      continue;
+    }
+    let cnt_ratio_s = r
+      .cnt_ratio
+      .map(|x| format!("{:.4}", x))
+      .unwrap_or_else(|| "inf".to_string());
+    let fee_ratio_s = r
+      .fee_ratio
+      .map(|x| format!("{:.4}", x))
+      .unwrap_or_else(|| "inf".to_string());
+    let vol_ratio_s = r
+      .vol_ratio
+      .map(|x| format!("{:.4}", x))
+      .unwrap_or_else(|| "inf".to_string());
+    output!(
+      "{:<44} {:<44} {:<11} {:<44} {:<10} {:<12} {:<9} {:<9} {:<9} {}",
+      r.receiver, r.asset, r.chain_id, r.output_token,
+      r.stored_cnt, r.computed_cnt,
+      cnt_ratio_s, fee_ratio_s, vol_ratio_s, r.status
+    );
+    printed_rows += 1;
+  }
+  if printed_rows == 0 {
+    output!("(no rows outside threshold)");
+  }
+
+  // Summary block.
+  output!("\nSUMMARY:");
+  output!("  partner_asset docs:                {}", stored_docs.len());
+  output!("  computed (receiver, asset) keys:   {}", computed.len());
+  output!("  rows total:                        {}", total_rows);
+  output!("  rows agreeing within threshold:    {} / {}", rows_ok, total_rows);
+  output!("  rows with drift:                   {}", rows_drift);
+  output!("  rows missing in partner_asset:     {}", rows_missing);
+  output!("  rows extra in partner_asset:       {} (no solver_volume backing)", rows_extra);
+  output!("  rows over-counted by stored:       {}", rows_over);
+  output!("  rows under-counted by stored:      {} (should be 0; investigate if not)", rows_under);
+  output!("  solver_volume rows aggregated:     {}", rows_aggregated);
+  output!("  solver_volume rows skipped (no fee data): {}", rows_skipped_no_fee);
+  if cnt_ratios.is_empty() {
+    output!("  max CNT_RATIO observed:            n/a");
+    output!("  min CNT_RATIO observed:            n/a");
+  } else {
+    output!("  max CNT_RATIO observed:            {:.4}", max_cnt_ratio);
+    output!("  min CNT_RATIO observed:            {:.4}", min_cnt_ratio);
+  }
+  let unique_s: Vec<String> = unique_cnt_ratios.iter().map(|r| format!("{:.3}", r)).collect();
+  output!("  unique CNT_RATIO values:           [{}]", unique_s.join(", "));
+  output!("\n=== Partner Asset Validation Complete ===");
 }
 
 #[cfg(test)]

--- a/src/intent_data_decoder.rs
+++ b/src/intent_data_decoder.rs
@@ -1,0 +1,215 @@
+// Ports `extractFeeIntentData` + `tryDecodeIntentData` from
+// sodax-backend `packages/shared-utils/src/utils/common-utils.ts:36-138, 419-438`.
+//
+// Encoded intent data uses a custom 1-byte dataType prefix followed by an
+// ABI-encoded payload:
+//
+//   0x{dataType:2 hex}{abi-encoded payload}
+//
+// dataType values (IntentDataType enum in the JS source):
+//   0 = ARRAY: a dynamic array of (uint8 dataType, bytes data) tuples
+//   1 = FEE:   (uint256 fee, address receiver)
+//   2 = HOOK:  ignored for partner_asset recomputation
+//
+// We DFS into ARRAY entries and return the first FEE encountered, matching
+// the JS `extractFeeIntentData` semantics exactly.
+
+use alloy::primitives::{Address, U256};
+use alloy::sol_types::SolValue;
+
+alloy::sol! {
+  struct ArrayEntry {
+    uint8 dataType;
+    bytes data;
+  }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FeeIntentData {
+  pub fee: U256,
+  pub receiver: Address,
+}
+
+pub fn extract_fee_from_intent_data(hex_str: &str) -> Option<FeeIntentData> {
+  let bytes = decode_hex(hex_str)?;
+  extract_fee_from_bytes(&bytes)
+}
+
+fn extract_fee_from_bytes(bytes: &[u8]) -> Option<FeeIntentData> {
+  if bytes.is_empty() {
+    return None;
+  }
+  let data_type = bytes[0];
+  let payload = &bytes[1..];
+
+  match data_type {
+    1 => decode_fee(payload),
+    0 => decode_array_and_find_fee(payload),
+    _ => None,
+  }
+}
+
+fn decode_fee(payload: &[u8]) -> Option<FeeIntentData> {
+  let (fee, receiver) = <(U256, Address) as SolValue>::abi_decode_params(payload).ok()?;
+  Some(FeeIntentData { fee, receiver })
+}
+
+fn decode_array_and_find_fee(payload: &[u8]) -> Option<FeeIntentData> {
+  // ARRAY payload is encoded as a single dynamic array of (uint8, bytes) tuples.
+  let entries: Vec<ArrayEntry> = <Vec<ArrayEntry> as SolValue>::abi_decode_params(payload).ok()?;
+  for entry in entries {
+    let mut nested = Vec::with_capacity(1 + entry.data.len());
+    nested.push(entry.dataType);
+    nested.extend_from_slice(entry.data.as_ref());
+    if let Some(result) = extract_fee_from_bytes(&nested) {
+      return Some(result);
+    }
+  }
+  None
+}
+
+fn decode_hex(hex_str: &str) -> Option<Vec<u8>> {
+  let trimmed = hex_str.strip_prefix("0x").unwrap_or(hex_str);
+  if trimmed.is_empty() {
+    return None;
+  }
+  alloy::hex::decode(trimmed).ok()
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use alloy::primitives::{address, Bytes};
+
+  fn encode_fee_blob(fee: U256, receiver: Address) -> Vec<u8> {
+    let payload = (fee, receiver).abi_encode_params();
+    let mut blob = Vec::with_capacity(1 + payload.len());
+    blob.push(1u8);
+    blob.extend_from_slice(&payload);
+    blob
+  }
+
+  fn encode_array_blob(entries: Vec<(u8, Vec<u8>)>) -> Vec<u8> {
+    let entries_alloy: Vec<ArrayEntry> = entries
+      .into_iter()
+      .map(|(t, d)| ArrayEntry {
+        dataType: t,
+        data: Bytes::from(d),
+      })
+      .collect();
+    let payload = entries_alloy.abi_encode_params();
+    let mut blob = Vec::with_capacity(1 + payload.len());
+    blob.push(0u8);
+    blob.extend_from_slice(&payload);
+    blob
+  }
+
+  fn to_hex(bytes: &[u8]) -> String {
+    format!("0x{}", alloy::hex::encode(bytes))
+  }
+
+  #[test]
+  fn decodes_fee() {
+    let fee = U256::from(123_456_789u64);
+    let receiver = address!("0x0Ab764AB3816cD036Ea951bE973098510D8105A6");
+    let hex = to_hex(&encode_fee_blob(fee, receiver));
+
+    let got = extract_fee_from_intent_data(&hex).unwrap();
+    assert_eq!(got.fee, fee);
+    assert_eq!(got.receiver, receiver);
+  }
+
+  #[test]
+  fn returns_none_for_hook() {
+    let payload = (
+      address!("0x0000000000000000000000000000000000000001"),
+      Bytes::from(vec![0xde, 0xad]),
+    )
+      .abi_encode_params();
+    let mut blob = vec![2u8];
+    blob.extend_from_slice(&payload);
+    let hex = to_hex(&blob);
+
+    assert!(extract_fee_from_intent_data(&hex).is_none());
+  }
+
+  #[test]
+  fn returns_none_for_unknown_data_type() {
+    let blob = vec![0x99u8, 0x00, 0x00];
+    let hex = to_hex(&blob);
+
+    assert!(extract_fee_from_intent_data(&hex).is_none());
+  }
+
+  #[test]
+  fn returns_none_for_empty_and_invalid() {
+    assert!(extract_fee_from_intent_data("").is_none());
+    assert!(extract_fee_from_intent_data("0x").is_none());
+    assert!(extract_fee_from_intent_data("0xnothex").is_none());
+    assert!(extract_fee_from_intent_data("0x01").is_none()); // FEE prefix with no payload
+  }
+
+  #[test]
+  fn decodes_array_with_single_fee_entry() {
+    let fee = U256::from(7777u64);
+    let receiver = address!("0x70178089842Be7f8E4726b33F0D1569dB8021fAa");
+    let fee_blob_without_prefix = (fee, receiver).abi_encode_params();
+    let entries = vec![(1u8, fee_blob_without_prefix)];
+    let hex = to_hex(&encode_array_blob(entries));
+
+    let got = extract_fee_from_intent_data(&hex).unwrap();
+    assert_eq!(got.fee, fee);
+    assert_eq!(got.receiver, receiver);
+  }
+
+  #[test]
+  fn dfs_finds_fee_after_hook_entry() {
+    let fee = U256::from(42u64);
+    let receiver = address!("0xdB7BdA65c3a1C51D64dC4444e418684677334109");
+
+    let hook_payload = (
+      address!("0x0000000000000000000000000000000000000abc"),
+      Bytes::from(vec![0x01, 0x02]),
+    )
+      .abi_encode_params();
+    let fee_payload = (fee, receiver).abi_encode_params();
+
+    let entries = vec![(2u8, hook_payload), (1u8, fee_payload)];
+    let hex = to_hex(&encode_array_blob(entries));
+
+    let got = extract_fee_from_intent_data(&hex).unwrap();
+    assert_eq!(got.fee, fee);
+    assert_eq!(got.receiver, receiver);
+  }
+
+  #[test]
+  fn decodes_nested_array_containing_fee() {
+    let fee = U256::from(1u128 << 100);
+    let receiver = address!("0x0c09e69a4528945de6d16c7E469deA6996Fdf636");
+    let inner_fee_payload = (fee, receiver).abi_encode_params();
+    let inner_entries = vec![(1u8, inner_fee_payload)];
+    let inner_array_blob = encode_array_blob(inner_entries);
+    // strip the outer prefix to use as inner `data`
+    let inner_array_payload = inner_array_blob[1..].to_vec();
+
+    let outer_entries = vec![(0u8, inner_array_payload)];
+    let hex = to_hex(&encode_array_blob(outer_entries));
+
+    let got = extract_fee_from_intent_data(&hex).unwrap();
+    assert_eq!(got.fee, fee);
+    assert_eq!(got.receiver, receiver);
+  }
+
+  #[test]
+  fn returns_none_when_array_has_no_fee() {
+    let hook_payload = (
+      address!("0x000000000000000000000000000000000000000A"),
+      Bytes::from(vec![]),
+    )
+      .abi_encode_params();
+    let entries = vec![(2u8, hook_payload)];
+    let hex = to_hex(&encode_array_blob(entries));
+
+    assert!(extract_fee_from_intent_data(&hex).is_none());
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod evm;
 pub mod functions;
 pub mod handlers;
 pub mod helpers;
+pub mod intent_data_decoder;
 pub mod models;
 pub mod report;
 pub mod structs;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use sodax_backend_analizer::handlers::{
   handle_validate_reserve_indexes, handle_validate_all_reserve_indexes,
   handle_calculate_from_events, handle_inspect_user_position,
   handle_validate_from_events, handle_validate_from_events_all,
+  handle_validate_partner_asset,
 };
 use sodax_backend_analizer::cli::parse_args;
 use sodax_backend_analizer::report::{init_report, report_path};
@@ -202,6 +203,14 @@ async fn main() {
     .any(|f: &Flag| matches!(f, Flag::CalculateFromEvents(_)))
   {
     handle_calculate_from_events(flags).await;
+    exit_success();
+
+  // if the --validate-partner-asset flag was passed
+  } else if flags
+    .iter()
+    .any(|f: &Flag| matches!(f, Flag::ValidatePartnerAsset))
+  {
+    handle_validate_partner_asset(flags).await;
     exit_success();
   }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -150,12 +150,42 @@ pub struct SolverVolumeDocument {
   pub txHash: String,
   pub intentHash: String,
   pub solver: String,
+  #[serde(default)]
+  pub inputToken: String,
   pub outputToken: String,
   pub amount: Decimal128,
   pub chainId: u64,
   pub blockNumber: u64,
+  #[serde(default)]
+  pub logIndex: i64,
   pub timestamp: Option<DateTime>,
-  data: String,
+  #[serde(default)]
+  pub data: String,
+  #[serde(rename = "__v")]
+  pub version: i32,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[allow(non_snake_case)]
+pub struct PartnerOutput {
+  pub totalVolumeOut: Decimal128,
+  pub totalFeeIn: Decimal128,
+  pub txCount: i64,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[allow(non_snake_case)]
+pub struct PartnerAssetDocument {
+  #[serde(rename = "_id")]
+  pub id: ObjectId,
+  pub receiver: String,
+  pub asset: String,
+  pub chainId: u64,
+  pub lastBlockNumber: u64,
+  #[serde(default)]
+  pub outputs: std::collections::HashMap<String, PartnerOutput>,
+  pub createdAt: DateTime,
+  pub updatedAt: DateTime,
   #[serde(rename = "__v")]
   pub version: i32,
 }

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -33,6 +33,10 @@ pub enum Flag {
   InspectUserPosition(String),
   ValidateFromEvents(String),
   ValidateFromEventsAll,
+  ValidatePartnerAsset,
+  Partner(String),
+  Json,
+  Threshold(f64),
 }
 #[derive(Debug, Clone)]
 pub struct EntryState {
@@ -130,6 +134,7 @@ pub struct Collections {
   pub eventlog_progress_metadata: &'static str,
   pub solver_volume: &'static str,
   pub user_balance_events: &'static str,
+  pub partner_asset: &'static str,
 }
 
 impl Default for Collections {
@@ -152,6 +157,7 @@ impl Collections {
       eventlog_progress_metadata: "event_log_progress_metadata",
       solver_volume: "solver_volume",
       user_balance_events: "user_balance_events",
+      partner_asset: "partner_asset",
     }
   }
 }
@@ -181,6 +187,7 @@ pub enum FlagType {
   Block,
   InspectUserPosition,
   ValidateFromEvents,
+  Partner,
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Closes #31.

## Summary

- New read-only CLI command `--validate-partner-asset` that recomputes the canonical `partner_asset` aggregate from `solver_volume` and reports per-row drift vs the stored values. Used to verify the `\$inc`-without-idempotency bug in the data-transformator before the backend team ships a one-shot rebuild.
- Ports `extractFeeIntentData` (sodax-backend `packages/shared-utils/src/utils/common-utils.ts`) to Rust in `src/intent_data_decoder.rs`, with round-trip unit tests covering FEE / ARRAY / nested ARRAY / HOOK / DFS-after-HOOK / malformed inputs.
- Corrects a stale schema note in `docs/sodax-backend/COLLECTIONS.md`: `partner_asset.outputs` is keyed by **output token address**, not solver address (authoritative writer is `partner-asset.service.ts:74-77` in sodax-backend, which builds the Mongo update path as `outputs.\${input.outputToken}.totalVolumeOut/.totalFeeIn/.txCount`; independently confirmed against live data on every deployment).

## CLI shape

```
--validate-partner-asset                    # full scan
--validate-partner-asset --partner <addr>   # single receiver
--validate-partner-asset --json             # machine-readable
--validate-partner-asset --threshold <pct>  # suppress in-band rows (default 0.0001)
```

## Test plan

- [x] \`cargo build\` — clean
- [x] \`cargo clippy --lib --bins\` — clean
- [x] \`cargo test --lib\` — 16/16 passing (including 8 new round-trip tests in \`intent_data_decoder\`)
- [x] CLI rejects \`--partner\` without \`--validate-partner-asset\`
- [x] CLI rejects \`--validate-partner-asset --reserve-token <addr>\` (companion not allowed)
- [x] \`--help\` advertises the new flags and four example invocations
- [ ] End-to-end on a deployment Mongo copy: \`unique CNT_RATIO values\` should expose the documented 3 / 6 / 8 multipliers from sodax-backend issue #498 §1. Owner step; this PR doesn't include a live-DB run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)