### PR TITLE
fix: print help on empty args instead of parse error

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -4,7 +4,7 @@ Complete reference for every flag accepted by the analyzer CLI.
 
 The binary is invoked as either `target/release/sodax_backend_analizer <flags...>` after `cargo build --release` (note: the package name in `Cargo.toml` is `sodax_backend_analizer` — with underscores and the legacy "analizer" spelling), or — most commonly during development — `cargo run -- <flags...>`. This document uses the latter form in examples; both behave identically.
 
-If invoked with no flags, the parser exits with status 1 and prints `Error parsing flags: Not enough arguments`. Use `--help` to print the help message.
+If invoked with no flags, the tool prints the help message and exits with status 0 (equivalent to passing `--help`).
 
 ## Contents
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,10 +5,6 @@ pub fn parse_args() -> Result<Vec<Flag>, Box<dyn std::error::Error>> {
   let args: Vec<String> = env::args().collect();
   let mut flags: Vec<Flag> = Vec::new();
 
-  if args.len() < 2 {
-    return Err("Not enough arguments".into());
-  }
-
   let mut i: usize = 1; // Start from 1 to skip the program name
   while i < args.len() {
     // Track whether this flag consumed the following argument


### PR DESCRIPTION
## Summary
- `parse_args()` previously returned `Err("Not enough arguments")` when invoked with no flags, causing the process to exit with status 1.
- The existing fallback at the bottom of `parse_args` (`if flags.is_empty() { flags.push(Flag::Help); }`) and `main.rs` setting `is_help = … || args.len() < 2` both indicate the intent was always to show help on empty args — the early `Err` made the fallback unreachable.
- Removes the early return; the empty-args path now falls through to the existing fallback and the user gets the help message.

This is the follow-up from PR #33 review feedback (Copilot + Codex flagged the doc claim that empty args prints help; the doc was right about intent, the code was wrong).

## Behavior change
| Invocation | Before | After |
|---|---|---|
| `sodax_backend_analizer` | `Error parsing flags: Not enough arguments` + exit 1 | Prints help + exit 0 |
| All other invocations | unchanged | unchanged |

## Test plan
- [x] `cargo check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo run` (no args) prints the help message (verified locally)
- [ ] `cargo run -- --help` still prints help (unchanged path)
- [ ] An unknown flag (e.g. `cargo run -- --nope`) still errors (unchanged path)

## Doc coordination
PR #33 (`docs/cli-reference`) currently documents the *old* behavior (says no-args errors with status 1). When both PRs land, the doc line in `docs/CLI.md` near the top should be flipped back to "no flags → prints help." If this PR merges first, that one line in the docs PR needs adjusting before merge. If the docs PR merges first, a one-line follow-up to `docs/CLI.md` will be needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)