### PR TITLE
feat: market-wide --calculate-from-events-reserve-all

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -79,14 +79,15 @@ Source of truth for the parser and dispatch:
 | `--validate-all` | — | opt. `--scaled` | Validate every reserve + every user |
 | `--calculate-from-events` | user | one token flag | Reconstruct balance from event history |
 | `--calculate-from-events-reserve` | reserve | opt. `--a-token-only`/`--debt-token-only`, `--verbose`, `--json` | Reconstruct balances for every user in a reserve |
-| `--a-token-only` | — | `--calculate-from-events-reserve` | Limit reserve replay to supply side |
-| `--debt-token-only` | — | `--calculate-from-events-reserve` | Limit reserve replay to debt side |
-| `--verbose` | — | `--calculate-from-events-reserve` | Print full per-user replay block instead of the compact table |
+| `--calculate-from-events-reserve-all` | — | opt. `--a-token-only`/`--debt-token-only`, `--json` | Reconstruct balances for every user in every reserve (market-wide health check) |
+| `--a-token-only` | — | `--calculate-from-events-reserve` / `--calculate-from-events-reserve-all` | Limit reserve replay to supply side |
+| `--debt-token-only` | — | `--calculate-from-events-reserve` / `--calculate-from-events-reserve-all` | Limit reserve replay to debt side |
+| `--verbose` | — | `--calculate-from-events-reserve` | Print full per-user replay block instead of the compact table (not valid with the -all variant) |
 | `--validate-from-events` | user | opt. `--reserve-token` | 3-way validate (events vs DB vs chain) for one user |
 | `--validate-from-events-all` | — | none | 3-way validate every user |
 | `--validate-partner-asset` | — | opt. `--partner`, `--json`, `--threshold` | Recompute `partner_asset` aggregates and report drift |
 | `--partner` | address | `--validate-partner-asset` | Restrict to one receiver |
-| `--json` | — | `--validate-partner-asset` or `--calculate-from-events-reserve` | Emit JSON output |
+| `--json` | — | `--validate-partner-asset`, `--calculate-from-events-reserve`, or `--calculate-from-events-reserve-all` | Emit JSON output |
 | `--threshold` | float | `--validate-partner-asset` | Suppress rows within ±PCT of 1.0 (default 0.0001) |
 | `--scaled` | — | validation flags | Compare scaled (raw) balances instead of real |
 
@@ -473,6 +474,43 @@ cargo run -- --calculate-from-events-reserve 0xreserve... --verbose
 cargo run -- --calculate-from-events-reserve 0xreserve... --json
 ```
 
+### `--calculate-from-events-reserve-all`
+
+Market-wide variant of `--calculate-from-events-reserve`: iterates **every reserve** returned by `find_all_reserves()` and runs the same per-user × per-side scaled-vs-scaled comparison for each. Designed for a regular health check across the whole money market — no need to keep a hand-maintained list of reserve addresses in sync.
+
+For each reserve the output mirrors the single-reserve flag's compact-table format (one supply table + one borrow table, with the same `Position Scaled` column and `Verdict` classification). At the end, the handler prints a **market-wide summary**: total reserves processed, aggregate verdict bucket counts (separately per side), and the list of reserves that contributed any `SIGNIFICANT` (❌), `MINOR` (⚠️), or `ERROR` (‼️) row on either side.
+
+**Per-reserve behavior:**
+- Reuses the existing replay helpers (`replay_side`, `print_replay_table`, `rows_summary_json`, `count_buckets`) — no separate code path for the per-reserve work.
+- `--a-token-only` / `--debt-token-only` apply across every reserve in the scan, exactly as for the single-reserve flag.
+- **Reserve-level failures don't abort the run.** If `find_token_events_sorted` fails for one side of one reserve (e.g. RPC hiccup, missing collection entry), every user on that side is counted as `ERROR` in both the per-reserve summary line and the market-wide aggregate, and the scan moves on to the next reserve. The fetch-error message is printed in place of the per-user table and surfaces as `fetchError` on the side in `--json` output.
+
+**`--verbose` is rejected.** Running the verbose per-event replay across every reserve produces unusable amounts of output; verbose's value is in single-reserve debugging via the existing `--calculate-from-events-reserve <ADDR> --verbose` form.
+
+**Concurrency.** Reserves are processed **sequentially**, one at a time. Each reserve already fans out up to 10 user replays in parallel internally; stacking reserve-level concurrency on top would multiply DB / RPC load. Peak in-flight concurrency stays at ~10 across the whole command — same as the single-reserve flag.
+
+**Performance.**
+- `user_positions` are prefetched once for the **union** of every selected side's user list across every reserve (case-insensitive). Users active in multiple reserves (the common case) hit the DB once instead of once-per-reserve. Bounded fan-out via `buffered(10)`, matching the existing prefetch helper.
+- Token events are still fetched once per reserve × selected side via `find_token_events_sorted`.
+
+**Output modes:**
+- Default (text): per-reserve section (header + supply table + borrow table + per-side summary line) for each reserve, followed by the market-wide summary block.
+- `--json`: emits a single JSON object `{ "reserves": [ ...per-reserve docs..., shaped exactly like --calculate-from-events-reserve --json output... ], "summary": { ...market-wide aggregate... } }`. Each per-reserve doc carries an optional `fetchError` string on `supply` / `borrow` when that side's event fetch failed. The market-wide `summary` includes `reservesProcessed`, `mode`, per-side `BucketCounts` (or `null` if the side was skipped), and the `reservesWithSignificant` / `reservesWithMinor` / `reservesWithErrors` lists (each an array of `{ "symbol", "reserve" }`).
+
+```bash
+# Compact market-wide scan (both sides)
+cargo run -- --calculate-from-events-reserve-all
+
+# Supply side only across every reserve
+cargo run -- --calculate-from-events-reserve-all --a-token-only
+
+# Debt side only across every reserve
+cargo run -- --calculate-from-events-reserve-all --debt-token-only
+
+# Machine-readable, for ingest into monitoring / CI
+cargo run -- --calculate-from-events-reserve-all --json
+```
+
 ### `--validate-from-events <USER_ADDRESS>`
 
 3-way validation for one user across all positions (or one position when filtered):
@@ -567,12 +605,13 @@ You cannot mix `--reserve-token`, `--a-token`, and `--debt-token` in a single in
 
 **Reserve event-replay subgroup:**
 - `--calculate-from-events-reserve` accepts `--a-token-only`, `--debt-token-only`, `--verbose`, `--json` (all optional).
-- `--a-token-only` and `--debt-token-only` are mutually exclusive.
-- `--verbose` and `--json` are mutually exclusive.
-- `--a-token-only`, `--debt-token-only`, `--verbose` are rejected if used without `--calculate-from-events-reserve`.
+- `--calculate-from-events-reserve-all` accepts `--a-token-only`, `--debt-token-only`, `--json` (all optional). `--verbose` is **rejected** because verbose output across every reserve is impractical — drill into a single reserve with `--calculate-from-events-reserve <ADDR> --verbose` instead.
+- `--a-token-only` and `--debt-token-only` are mutually exclusive (applies to both flags).
+- `--verbose` and `--json` are mutually exclusive (single-reserve flag only).
+- `--a-token-only` / `--debt-token-only` are rejected if used without one of the reserve-event-replay flags. `--verbose` is rejected if used without `--calculate-from-events-reserve`.
 
 **Shared modifier:**
-- `--json` is valid with either `--validate-partner-asset` or `--calculate-from-events-reserve`; rejected otherwise.
+- `--json` is valid with `--validate-partner-asset`, `--calculate-from-events-reserve`, or `--calculate-from-events-reserve-all`; rejected otherwise.
 
 **Event-replay companions:**
 - `--validate-from-events` accepts `--reserve-token` (optional). No other combinations.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -109,6 +109,10 @@ pub fn parse_args() -> Result<Vec<Flag>, Box<dyn std::error::Error>> {
         flags.push(Flag::CalculateFromEventsReserve(args[i + 1].clone()));
         consumed_next_arg = true;
       }
+      "--calculate-from-events-reserve-all" => {
+        validate_flag_does_not_accept_argument(i, &args)?;
+        flags.push(Flag::CalculateFromEventsReserveAll);
+      }
       "--a-token-only" => {
         validate_flag_does_not_accept_argument(i, &args)?;
         flags.push(Flag::ATokenOnly);
@@ -427,6 +431,9 @@ pub fn parse_args() -> Result<Vec<Flag>, Box<dyn std::error::Error>> {
   let has_calculate_from_events_reserve = flags
     .iter()
     .any(|flag| matches!(flag, Flag::CalculateFromEventsReserve(_)));
+  let has_calculate_from_events_reserve_all = flags
+    .iter()
+    .any(|flag| matches!(flag, Flag::CalculateFromEventsReserveAll));
   let has_a_token_only = flags.iter().any(|flag| matches!(flag, Flag::ATokenOnly));
   let has_debt_token_only = flags.iter().any(|flag| matches!(flag, Flag::DebtTokenOnly));
   if has_calculate_from_events_reserve {
@@ -455,10 +462,29 @@ pub fn parse_args() -> Result<Vec<Flag>, Box<dyn std::error::Error>> {
     }
   }
 
+  // --calculate-from-events-reserve-all is the market-wide variant. It accepts the same
+  // companions as --calculate-from-events-reserve except --verbose: running the verbose
+  // per-event replay across every reserve in the market produces unusable amounts of
+  // output, so verbose's value is restricted to single-reserve debugging.
+  if has_calculate_from_events_reserve_all {
+    let allowed_companions = flags.iter().all(|flag| {
+      matches!(
+        flag,
+        Flag::CalculateFromEventsReserveAll | Flag::ATokenOnly | Flag::DebtTokenOnly | Flag::Json
+      )
+    });
+    if !allowed_companions {
+      return Err("--calculate-from-events-reserve-all can only be combined with --a-token-only, --debt-token-only, --json. Use --help for more information.".into());
+    }
+    if has_a_token_only && has_debt_token_only {
+      return Err("--a-token-only and --debt-token-only are mutually exclusive.".into());
+    }
+  }
+
   // --partner and --threshold are only valid alongside --validate-partner-asset.
-  // --json is valid with --validate-partner-asset OR --calculate-from-events-reserve.
-  // --a-token-only, --debt-token-only, --verbose are only valid alongside
-  // --calculate-from-events-reserve.
+  // --json is valid with --validate-partner-asset OR either of the reserve-event-replay
+  // flags. --a-token-only / --debt-token-only / --verbose pair only with the
+  // reserve-event-replay flags (verbose with the single-reserve variant only).
   let has_partner_only_companion = flags
     .iter()
     .any(|flag| matches!(flag, Flag::Partner(_) | Flag::Threshold(_)));
@@ -467,13 +493,23 @@ pub fn parse_args() -> Result<Vec<Flag>, Box<dyn std::error::Error>> {
   }
 
   let has_json = flags.iter().any(|flag| matches!(flag, Flag::Json));
-  if has_json && !has_validate_partner_asset && !has_calculate_from_events_reserve {
-    return Err("--json can only be used with --validate-partner-asset or --calculate-from-events-reserve.".into());
+  if has_json
+    && !has_validate_partner_asset
+    && !has_calculate_from_events_reserve
+    && !has_calculate_from_events_reserve_all
+  {
+    return Err("--json can only be used with --validate-partner-asset, --calculate-from-events-reserve, or --calculate-from-events-reserve-all.".into());
   }
 
   let has_verbose = flags.iter().any(|flag| matches!(flag, Flag::Verbose));
-  if (has_a_token_only || has_debt_token_only || has_verbose) && !has_calculate_from_events_reserve {
-    return Err("--a-token-only, --debt-token-only and --verbose can only be used with --calculate-from-events-reserve.".into());
+  if has_verbose && !has_calculate_from_events_reserve {
+    return Err("--verbose can only be used with --calculate-from-events-reserve.".into());
+  }
+  if (has_a_token_only || has_debt_token_only)
+    && !has_calculate_from_events_reserve
+    && !has_calculate_from_events_reserve_all
+  {
+    return Err("--a-token-only and --debt-token-only can only be used with --calculate-from-events-reserve or --calculate-from-events-reserve-all.".into());
   }
 
   // the following flags need to be used acompanied by

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -28,9 +28,10 @@ OPTIONS:
     --get-user-events <USER_ADDRESS>  Get events for a specific user
     --calculate-from-events <USER_ADDRESS>  Calculate user's token balance from events (requires one of: --reserve-token, --a-token, or --debt-token)
     --calculate-from-events-reserve <RESERVE_ADDRESS>  Calculate token balances from events for every user in a reserve (compact table by default)
-    --a-token-only                          Restrict --calculate-from-events-reserve to supply (aToken) side only
-    --debt-token-only                       Restrict --calculate-from-events-reserve to variable-debt side only
-    --verbose                               With --calculate-from-events-reserve, print the full per-user replay block instead of the compact table
+    --calculate-from-events-reserve-all     Run --calculate-from-events-reserve across every reserve in the marketplace and emit a market-wide summary
+    --a-token-only                          Restrict --calculate-from-events-reserve / --calculate-from-events-reserve-all to supply (aToken) side only
+    --debt-token-only                       Restrict --calculate-from-events-reserve / --calculate-from-events-reserve-all to variable-debt side only
+    --verbose                               With --calculate-from-events-reserve, print the full per-user replay block instead of the compact table (not valid with the -all variant)
     --inspect-user-position <USER_ADDRESS>  Inspect detailed user position for a specific token (requires either --a-token or --debt-token)
     --scaled                 Use scaled balances instead of real balances for validation (adds to validation flags)
     --no-report              Disable automatic report file generation (reports are saved to reports/ by default)
@@ -52,7 +53,7 @@ BULK VALIDATION OPTIONS:
     --validate-from-events-all           Validate all users by replaying raw events
     --validate-partner-asset             Recompute partner_asset aggregates from solver_volume and report drift
     --partner <ADDRESS>                  Optional: limit --validate-partner-asset to a single receiver address
-    --json                               Optional: emit JSON output (valid with --validate-partner-asset or --calculate-from-events-reserve)
+    --json                               Optional: emit JSON output (valid with --validate-partner-asset, --calculate-from-events-reserve, or --calculate-from-events-reserve-all)
     --threshold <PCT>                    Optional: rows within ±PCT of 1.0 are suppressed from the --validate-partner-asset table (default 0.0001)
 
 SCALED VALIDATION:
@@ -135,6 +136,11 @@ EXAMPLES:
     sodax-backend-analizer --calculate-from-events-reserve 0xreserve... --debt-token-only
     sodax-backend-analizer --calculate-from-events-reserve 0xreserve... --verbose
     sodax-backend-analizer --calculate-from-events-reserve 0xreserve... --json
+
+    # Market-wide event replay (every reserve)
+    sodax-backend-analizer --calculate-from-events-reserve-all
+    sodax-backend-analizer --calculate-from-events-reserve-all --a-token-only
+    sodax-backend-analizer --calculate-from-events-reserve-all --json
 
     # Partner asset drift validation (recompute from solver_volume)
     sodax-backend-analizer --validate-partner-asset

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -3246,6 +3246,18 @@ async fn run_reserve_side(
       reserve.borrowers.as_slice(),
     ),
   };
+  // Short-circuit zero-user sides BEFORE fetching events. A reserve with no
+  // suppliers/borrowers on this side has nothing to replay, so spending a DB roundtrip
+  // on its event stream is wasted — and worse, if that fetch happens to fail (token
+  // never traded, RPC blip, etc.) the side would surface as a fetch_error and land in
+  // `reservesWithErrors`, producing false-positive alerts for reserves that didn't
+  // actually drift. Treat empty sides as neutral instead.
+  if users.is_empty() {
+    return ReserveSideResult {
+      rows: Vec::new(),
+      fetch_error: None,
+    };
+  }
   let token_events = match find_token_events_sorted(token_address).await {
     Ok(events) => Arc::new(events),
     Err(e) => {

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -2901,6 +2901,20 @@ struct BucketCounts {
   errors: u64,
 }
 
+impl BucketCounts {
+  fn total(&self) -> u64 {
+    self.perfect + self.excellent + self.minor + self.significant + self.errors
+  }
+
+  fn add(&mut self, other: &BucketCounts) {
+    self.perfect += other.perfect;
+    self.excellent += other.excellent;
+    self.minor += other.minor;
+    self.significant += other.significant;
+    self.errors += other.errors;
+  }
+}
+
 fn count_buckets(rows: &[ReserveReplayRow]) -> BucketCounts {
   let mut counts = BucketCounts::default();
   for row in rows {
@@ -3205,6 +3219,396 @@ pub async fn handle_calculate_from_events_reserve(flags: Vec<Flag>) {
   output!("\n=== Reserve Event-Replay Reconstruction Complete ===");
 }
 
+// ============================================================
+// --calculate-from-events-reserve-all handler
+// ============================================================
+
+/// Per-reserve, per-side replay result. `fetch_error` is set when the token-event fetch
+/// itself failed; in that case `rows` is populated with one synthetic ERROR row per user
+/// on that side, so bucket counts / JSON shape stay consistent with the success path.
+/// The marker is still kept so text mode can print a single error line rather than N
+/// duplicate rows.
+#[derive(Debug, Clone)]
+struct ReserveSideResult {
+  rows: Vec<ReserveReplayRow>,
+  fetch_error: Option<String>,
+}
+
+async fn run_reserve_side(
+  reserve: &ReserveTokenDocument,
+  side: PositionSide,
+  positions_cache: &PositionsCache,
+) -> ReserveSideResult {
+  let (token_address, users) = match side {
+    PositionSide::Supply => (reserve.aTokenAddress.as_str(), reserve.suppliers.as_slice()),
+    PositionSide::Borrow => (
+      reserve.variableDebtTokenAddress.as_str(),
+      reserve.borrowers.as_slice(),
+    ),
+  };
+  let token_events = match find_token_events_sorted(token_address).await {
+    Ok(events) => Arc::new(events),
+    Err(e) => {
+      // Reserve-level event fetch failure. Synthesize one ERROR row per user so the
+      // per-reserve summary line / aggregate counts still reflect the right number of
+      // users on this side, and JSON consumers get a uniform `rows` shape across reserves.
+      let msg = format!("token-event fetch failed: {}", e);
+      let rows = users
+        .iter()
+        .map(|u| err_row(u.clone(), msg.clone()))
+        .collect();
+      return ReserveSideResult {
+        rows,
+        fetch_error: Some(msg),
+      };
+    }
+  };
+  let rows = replay_side(
+    users,
+    token_address,
+    &reserve.reserveAddress,
+    side,
+    false, // never verbose for the market-wide scan
+    token_events,
+    positions_cache,
+    RAY,
+  )
+  .await;
+  ReserveSideResult {
+    rows,
+    fetch_error: None,
+  }
+}
+
+fn print_reserve_side(label: &str, token_address: &str, result: &ReserveSideResult) {
+  match &result.fetch_error {
+    Some(err) => {
+      // Suppress the per-user table — the rows are all duplicate synthetic errors. Emit
+      // one error line plus the standard summary so aggregate counts stay readable.
+      output!("\n=== {} ({}) ===", label, token_address);
+      output!(
+        "‼️ Fetch failed: {} ({} users counted as ERROR)",
+        err,
+        result.rows.len()
+      );
+      let c = count_buckets(&result.rows);
+      output!(
+        "\nSummary ({}): {} users  ·  ✅ {} perfect / {} excellent  ·  ⚠️ {} minor  ·  ❌ {} significant  ·  ‼️ {} errors",
+        label,
+        result.rows.len(),
+        c.perfect,
+        c.excellent,
+        c.minor,
+        c.significant,
+        c.errors,
+      );
+    }
+    None => print_replay_table(label, token_address, &result.rows),
+  }
+}
+
+fn reserve_side_json(result: &ReserveSideResult) -> serde_json::Value {
+  let mut doc = serde_json::json!({
+    "users": rows_to_json(&result.rows),
+    "summary": rows_summary_json(&result.rows),
+  });
+  if let Some(err) = &result.fetch_error {
+    doc["fetchError"] = serde_json::Value::String(err.clone());
+  }
+  doc
+}
+
+/// Tracks reserves that contributed any non-green verdict, for the market-wide summary
+/// section. Each entry is `(symbol, reserveAddress)` so the printout / JSON identifies
+/// the offender unambiguously even if symbols ever collide.
+#[derive(Debug, Default, Clone)]
+struct MarketNonGreenReserves {
+  significant: Vec<(String, String)>,
+  minor: Vec<(String, String)>,
+  errors: Vec<(String, String)>,
+}
+
+fn reserve_side_has_significant(r: &ReserveSideResult) -> bool {
+  count_buckets(&r.rows).significant > 0
+}
+
+fn reserve_side_has_minor(r: &ReserveSideResult) -> bool {
+  count_buckets(&r.rows).minor > 0
+}
+
+fn reserve_side_has_errors(r: &ReserveSideResult) -> bool {
+  // Either a side-level fetch error (already counted via synthetic rows) or any
+  // individual row classified ERROR (e.g. last_event_block == 0 for a user).
+  r.fetch_error.is_some() || count_buckets(&r.rows).errors > 0
+}
+
+fn build_market_summary_json(
+  reserves_processed: u64,
+  mode: &str,
+  supply: Option<BucketCounts>,
+  borrow: Option<BucketCounts>,
+  non_green: &MarketNonGreenReserves,
+) -> serde_json::Value {
+  let bucket_to_json = |c: BucketCounts| -> serde_json::Value {
+    serde_json::json!({
+      "totalUsers": c.total(),
+      "perfect": c.perfect,
+      "excellent": c.excellent,
+      "minor": c.minor,
+      "significant": c.significant,
+      "errors": c.errors,
+    })
+  };
+  let list_to_json = |list: &[(String, String)]| -> serde_json::Value {
+    serde_json::Value::Array(
+      list
+        .iter()
+        .map(|(sym, addr)| serde_json::json!({ "symbol": sym, "reserve": addr }))
+        .collect(),
+    )
+  };
+  serde_json::json!({
+    "reservesProcessed": reserves_processed,
+    "mode": mode,
+    "supply": supply.map(bucket_to_json),
+    "borrow": borrow.map(bucket_to_json),
+    "reservesWithSignificant": list_to_json(&non_green.significant),
+    "reservesWithMinor": list_to_json(&non_green.minor),
+    "reservesWithErrors": list_to_json(&non_green.errors),
+  })
+}
+
+pub async fn handle_calculate_from_events_reserve_all(flags: Vec<Flag>) {
+  let a_token_only = flags.iter().any(|f| matches!(f, Flag::ATokenOnly));
+  let debt_token_only = flags.iter().any(|f| matches!(f, Flag::DebtTokenOnly));
+  let output_json = flags.iter().any(|f| matches!(f, Flag::Json));
+
+  let do_supply = !debt_token_only;
+  let do_borrow = !a_token_only;
+
+  let mode_label = if a_token_only {
+    "supply only"
+  } else if debt_token_only {
+    "borrow only"
+  } else {
+    "supply + borrow"
+  };
+
+  let reserves = match find_all_reserves().await {
+    Ok(r) => r,
+    Err(e) => {
+      eprintln!("Error fetching reserves: {}", e);
+      std::process::exit(1);
+    }
+  };
+
+  if reserves.is_empty() {
+    if output_json {
+      let out = serde_json::json!({
+        "reserves": [],
+        "summary": build_market_summary_json(
+          0,
+          mode_label,
+          do_supply.then(BucketCounts::default),
+          do_borrow.then(BucketCounts::default),
+          &MarketNonGreenReserves::default(),
+        ),
+      });
+      output!("{}", serde_json::to_string_pretty(&out).unwrap());
+      return;
+    }
+    output!("\n=== Money Market Event-Replay Reconstruction ===");
+    output!("No reserves found in the database.");
+    return;
+  }
+
+  if !output_json {
+    output!("\n=== Money Market Event-Replay Reconstruction ===");
+    output!("Total reserves: {} · Mode: {}", reserves.len(), mode_label);
+  }
+
+  // Prefetch user_positions for the union of every reserve's suppliers + borrowers in a
+  // single batch. Users active in multiple reserves (the common case across a market)
+  // would otherwise hit the DB once per reserve they appear in. The cache is keyed by
+  // lowercased address so per-reserve lookups work regardless of casing.
+  let unique_users: Vec<String> = {
+    let mut set: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for r in &reserves {
+      if do_supply {
+        for u in &r.suppliers {
+          set.insert(u.to_lowercase());
+        }
+      }
+      if do_borrow {
+        for u in &r.borrowers {
+          set.insert(u.to_lowercase());
+        }
+      }
+    }
+    set.into_iter().collect()
+  };
+  if !output_json {
+    output!(
+      "Prefetching user_positions for {} unique users (union across all reserves)…",
+      unique_users.len()
+    );
+  }
+  let positions_cache = prefetch_user_positions(&unique_users).await;
+
+  // Process reserves sequentially. Each reserve already fans out up to 10 user replays
+  // in parallel internally (RESERVE_REPLAY_CONCURRENCY in replay_side); stacking
+  // reserve-level parallelism on top would multiply DB / RPC load without bounding peak
+  // concurrency. Sequential keeps peak concurrency at ~10 across the whole command.
+  let mut market_supply = BucketCounts::default();
+  let mut market_borrow = BucketCounts::default();
+  let mut non_green = MarketNonGreenReserves::default();
+  let mut reserve_json_docs: Vec<serde_json::Value> = Vec::new();
+
+  let total = reserves.len();
+  for (idx, reserve) in reserves.iter().enumerate() {
+    if !output_json {
+      output!(
+        "\n[{}/{}] Reserve {} ({}) ─────────────────────────",
+        idx + 1,
+        total,
+        reserve.symbol,
+        reserve.reserveAddress
+      );
+    }
+
+    let supply_result = if do_supply {
+      Some(run_reserve_side(reserve, PositionSide::Supply, &positions_cache).await)
+    } else {
+      None
+    };
+    let borrow_result = if do_borrow {
+      Some(run_reserve_side(reserve, PositionSide::Borrow, &positions_cache).await)
+    } else {
+      None
+    };
+
+    // Accumulate market-wide bucket totals before consuming the per-reserve results.
+    if let Some(r) = &supply_result {
+      market_supply.add(&count_buckets(&r.rows));
+    }
+    if let Some(r) = &borrow_result {
+      market_borrow.add(&count_buckets(&r.rows));
+    }
+
+    // Flag the reserve in the non-green lists if any selected side hit a non-green bucket.
+    let any_side = |pred: fn(&ReserveSideResult) -> bool| -> bool {
+      supply_result.as_ref().is_some_and(pred) || borrow_result.as_ref().is_some_and(pred)
+    };
+    let has_significant = any_side(reserve_side_has_significant);
+    let has_minor = any_side(reserve_side_has_minor);
+    let has_errors = any_side(reserve_side_has_errors);
+    if has_significant {
+      non_green
+        .significant
+        .push((reserve.symbol.clone(), reserve.reserveAddress.clone()));
+    }
+    if has_minor {
+      non_green
+        .minor
+        .push((reserve.symbol.clone(), reserve.reserveAddress.clone()));
+    }
+    if has_errors {
+      non_green
+        .errors
+        .push((reserve.symbol.clone(), reserve.reserveAddress.clone()));
+    }
+
+    if output_json {
+      let mut doc = serde_json::json!({
+        "reserve": reserve.reserveAddress,
+        "symbol": reserve.symbol,
+        "aTokenAddress": reserve.aTokenAddress,
+        "variableDebtTokenAddress": reserve.variableDebtTokenAddress,
+        "mode": mode_label,
+        "comparison": "scaled-vs-scaled",
+      });
+      if let Some(r) = &supply_result {
+        doc["supply"] = reserve_side_json(r);
+      }
+      if let Some(r) = &borrow_result {
+        doc["borrow"] = reserve_side_json(r);
+      }
+      reserve_json_docs.push(doc);
+    } else {
+      if let Some(r) = &supply_result {
+        print_reserve_side("Supply", &reserve.aTokenAddress, r);
+      }
+      if let Some(r) = &borrow_result {
+        print_reserve_side("Borrow", &reserve.variableDebtTokenAddress, r);
+      }
+    }
+  }
+
+  if output_json {
+    let summary = build_market_summary_json(
+      total as u64,
+      mode_label,
+      do_supply.then_some(market_supply),
+      do_borrow.then_some(market_borrow),
+      &non_green,
+    );
+    let out = serde_json::json!({
+      "reserves": reserve_json_docs,
+      "summary": summary,
+    });
+    output!("{}", serde_json::to_string_pretty(&out).unwrap());
+    return;
+  }
+
+  output!("\n=== Market-Wide Summary ===");
+  output!("Reserves processed: {}", total);
+  if do_supply {
+    output!(
+      "Supply users: {}  ·  ✅ {} / {}  ·  ⚠️ {}  ·  ❌ {}  ·  ‼️ {}",
+      market_supply.total(),
+      market_supply.perfect,
+      market_supply.excellent,
+      market_supply.minor,
+      market_supply.significant,
+      market_supply.errors,
+    );
+  }
+  if do_borrow {
+    output!(
+      "Borrow users: {}  ·  ✅ {} / {}  ·  ⚠️ {}  ·  ❌ {}  ·  ‼️ {}",
+      market_borrow.total(),
+      market_borrow.perfect,
+      market_borrow.excellent,
+      market_borrow.minor,
+      market_borrow.significant,
+      market_borrow.errors,
+    );
+  }
+  let fmt_list = |list: &[(String, String)]| -> String {
+    if list.is_empty() {
+      return "0".to_string();
+    }
+    let items: Vec<String> = list
+      .iter()
+      .map(|(sym, addr)| format!("{} / {}", sym, addr))
+      .collect();
+    format!("{} ({})", list.len(), items.join(", "))
+  };
+  output!(
+    "Reserves with at least one ❌: {}",
+    fmt_list(&non_green.significant)
+  );
+  output!(
+    "Reserves with at least one ⚠️: {}",
+    fmt_list(&non_green.minor)
+  );
+  output!(
+    "Reserves with at least one ‼️: {}",
+    fmt_list(&non_green.errors)
+  );
+  output!("\n=== Money Market Event-Replay Reconstruction Complete ===");
+}
+
 #[cfg(test)]
 mod tests {
   use super::*;
@@ -3485,5 +3889,167 @@ mod tests {
     let diff = u128::MAX / 50; // diff*100 overflows
     assert_eq!(classify_verdict(diff, 1, false), "SIGNIFICANT");
     assert_eq!(classify_verdict(diff, u128::MAX, false), "SIGNIFICANT");
+  }
+
+  // ----------------------------------------------------------
+  // --calculate-from-events-reserve-all aggregation
+  // ----------------------------------------------------------
+
+  #[test]
+  fn bucket_counts_total_sums_all_fields() {
+    let c = BucketCounts {
+      perfect: 1,
+      excellent: 2,
+      minor: 3,
+      significant: 4,
+      errors: 5,
+    };
+    assert_eq!(c.total(), 15);
+  }
+
+  #[test]
+  fn bucket_counts_add_accumulates_each_field() {
+    let mut a = BucketCounts {
+      perfect: 1,
+      excellent: 2,
+      minor: 3,
+      significant: 4,
+      errors: 5,
+    };
+    let b = BucketCounts {
+      perfect: 10,
+      excellent: 20,
+      minor: 30,
+      significant: 40,
+      errors: 50,
+    };
+    a.add(&b);
+    assert_eq!(a.perfect, 11);
+    assert_eq!(a.excellent, 22);
+    assert_eq!(a.minor, 33);
+    assert_eq!(a.significant, 44);
+    assert_eq!(a.errors, 55);
+    assert_eq!(a.total(), 165);
+  }
+
+  #[test]
+  fn bucket_counts_add_default_is_identity() {
+    let mut a = BucketCounts {
+      perfect: 7,
+      excellent: 0,
+      minor: 0,
+      significant: 1,
+      errors: 0,
+    };
+    a.add(&BucketCounts::default());
+    assert_eq!(a.perfect, 7);
+    assert_eq!(a.significant, 1);
+    assert_eq!(a.total(), 8);
+  }
+
+  /// Reserve-side helpers should consider the side green when every row classifies as
+  /// PERFECT / EXCELLENT and no fetch_error is set. This is the dominant path on healthy
+  /// markets, so getting it right keeps the market-wide summary uncluttered.
+  #[test]
+  fn reserve_side_has_helpers_all_false_on_green_rows() {
+    let result = ReserveSideResult {
+      rows: vec![ok_row(0, 100), ok_row(1, 20_000)], // PERFECT + EXCELLENT
+      fetch_error: None,
+    };
+    assert!(!reserve_side_has_significant(&result));
+    assert!(!reserve_side_has_minor(&result));
+    assert!(!reserve_side_has_errors(&result));
+  }
+
+  #[test]
+  fn reserve_side_has_significant_detects_any_significant_row() {
+    let result = ReserveSideResult {
+      rows: vec![ok_row(0, 100), ok_row(1, 100)], // PERFECT + SIGNIFICANT (1%)
+      fetch_error: None,
+    };
+    assert!(reserve_side_has_significant(&result));
+  }
+
+  #[test]
+  fn reserve_side_has_minor_detects_any_minor_row() {
+    let result = ReserveSideResult {
+      rows: vec![ok_row(0, 100), ok_row(5, 10_000)], // PERFECT + MINOR
+      fetch_error: None,
+    };
+    assert!(reserve_side_has_minor(&result));
+    assert!(!reserve_side_has_significant(&result));
+  }
+
+  #[test]
+  fn reserve_side_has_errors_when_fetch_error_set() {
+    // Synthetic ERROR rows would also flip count_buckets().errors > 0, but the
+    // fetch_error marker alone is enough — even on an empty users list.
+    let result = ReserveSideResult {
+      rows: Vec::new(),
+      fetch_error: Some("rpc unreachable".to_string()),
+    };
+    assert!(reserve_side_has_errors(&result));
+  }
+
+  #[test]
+  fn reserve_side_has_errors_when_individual_row_errors() {
+    let mut row = ok_row(0, 100);
+    row.error = Some("boom".to_string());
+    let result = ReserveSideResult {
+      rows: vec![row],
+      fetch_error: None,
+    };
+    assert!(reserve_side_has_errors(&result));
+  }
+
+  #[test]
+  fn market_summary_json_emits_bucket_and_reserve_lists() {
+    let supply = BucketCounts {
+      perfect: 10,
+      excellent: 5,
+      minor: 1,
+      significant: 0,
+      errors: 0,
+    };
+    let borrow = BucketCounts {
+      perfect: 3,
+      excellent: 2,
+      minor: 0,
+      significant: 1,
+      errors: 0,
+    };
+    let non_green = MarketNonGreenReserves {
+      significant: vec![("sodaSUI".to_string(), "0xdc5b".to_string())],
+      minor: vec![("sodaSUI".to_string(), "0xdc5b".to_string())],
+      errors: vec![],
+    };
+    let v = build_market_summary_json(7, "supply + borrow", Some(supply), Some(borrow), &non_green);
+    assert_eq!(v["reservesProcessed"], 7);
+    assert_eq!(v["mode"], "supply + borrow");
+    assert_eq!(v["supply"]["totalUsers"], 16);
+    assert_eq!(v["supply"]["perfect"], 10);
+    assert_eq!(v["supply"]["minor"], 1);
+    assert_eq!(v["borrow"]["totalUsers"], 6);
+    assert_eq!(v["borrow"]["significant"], 1);
+    assert_eq!(v["reservesWithSignificant"][0]["symbol"], "sodaSUI");
+    assert_eq!(v["reservesWithSignificant"][0]["reserve"], "0xdc5b");
+    assert_eq!(v["reservesWithMinor"].as_array().unwrap().len(), 1);
+    assert_eq!(v["reservesWithErrors"].as_array().unwrap().len(), 0);
+  }
+
+  #[test]
+  fn market_summary_json_emits_null_for_skipped_side() {
+    // Mode = supply only → borrow bucket is None and should serialize as null so JSON
+    // consumers can distinguish "skipped" from "zero users".
+    let supply = BucketCounts::default();
+    let v = build_market_summary_json(
+      0,
+      "supply only",
+      Some(supply),
+      None,
+      &MarketNonGreenReserves::default(),
+    );
+    assert!(v["supply"].is_object());
+    assert!(v["borrow"].is_null());
   }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use sodax_backend_analizer::handlers::{
   handle_get_all_debt_tokens, handle_get_token_events, handle_get_user_events,
   handle_validate_reserve_indexes, handle_validate_all_reserve_indexes,
   handle_calculate_from_events, handle_calculate_from_events_reserve,
+  handle_calculate_from_events_reserve_all,
   handle_inspect_user_position,
   handle_validate_from_events, handle_validate_from_events_all,
   handle_validate_partner_asset,
@@ -212,6 +213,14 @@ async fn main() {
     .any(|f: &Flag| matches!(f, Flag::CalculateFromEventsReserve(_)))
   {
     handle_calculate_from_events_reserve(flags).await;
+    exit_success();
+
+  // if the --calculate-from-events-reserve-all flag was passed
+  } else if flags
+    .iter()
+    .any(|f: &Flag| matches!(f, Flag::CalculateFromEventsReserveAll))
+  {
+    handle_calculate_from_events_reserve_all(flags).await;
     exit_success();
 
   // if the --validate-partner-asset flag was passed

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -30,6 +30,7 @@ pub enum Flag {
   ValidateAllReserveIndexes,
   CalculateFromEvents(String),
   CalculateFromEventsReserve(String),
+  CalculateFromEventsReserveAll,
   ATokenOnly,
   DebtTokenOnly,
   Verbose,


### PR DESCRIPTION
## Summary

Adds `--calculate-from-events-reserve-all`, a market-wide variant of `--calculate-from-events-reserve` that iterates every reserve in `reserve_tokens` and runs the same three-way scaled-balance comparison (events / `user_positions` / chain) for each. Designed for a periodic health check across the whole money market — no need to keep a hand-maintained list of reserve addresses in sync.

For each reserve the output mirrors the single-reserve flag's compact-table format (supply table + borrow table with the existing `Position Scaled` column and verdict classification). At the end, a **market-wide summary** prints aggregate verdict bucket counts per side and the list of reserves that contributed any `SIGNIFICANT` (❌), `MINOR` (⚠️), or `ERROR` (‼️) row.

Closes #37.

## Behavior

- **Per-reserve work reuses the existing helpers** from PR #36 (`replay_side`, `print_replay_table`, `rows_to_json`, `rows_summary_json`, `count_buckets`, `prefetch_user_positions`, `lookup_position_scaled`, `replay_one_user`) — no duplicated replay logic.
- **Sequential reserve processing.** Each reserve already runs up to 10 user replays in parallel internally; stacking reserve-level parallelism would multiply DB/RPC load. Peak in-flight concurrency stays at ~10 across the whole command.
- **One global `user_positions` prefetch** for the case-insensitive union of every selected side's user list across every reserve. Users active in multiple reserves (the common case) hit the DB once instead of once per reserve.
- **Reserve-level failures don't abort.** If `find_token_events_sorted` fails for one side of one reserve, every user on that side is counted as `ERROR` (synthetic err_rows so JSON shape stays consistent) and the scan continues. The fetch error surfaces as a one-line message in text mode and as `fetchError` on the side in `--json` output.

## Companion flags

Matches the single-reserve variant:
- `--a-token-only` / `--debt-token-only` — mutually exclusive; restrict to one side across every reserve.
- `--json` — emits `{ "reserves": [...per-reserve docs shaped like --calculate-from-events-reserve --json...], "summary": {...market-wide aggregate...} }`.

**`--verbose` is rejected** for this flag (Open question 1 in the issue). Running the verbose per-event replay across every reserve produces unusable amounts of output; verbose's value is in single-reserve debugging via the existing `--calculate-from-events-reserve <ADDR> --verbose` form. (Other open questions: reserve-level failures continue with an aggregate `ERROR` row — resolved above; `--threshold-fail` for CI exit codes deferred to a follow-up.)

## Files

- `src/structs.rs` — new `Flag::CalculateFromEventsReserveAll` variant.
- `src/cli.rs` — parser entry, combination rules (accepts `--a-token-only`/`--debt-token-only`/`--json`, rejects `--verbose`).
- `src/handlers.rs` — new `handle_calculate_from_events_reserve_all` handler, `ReserveSideResult` + `MarketNonGreenReserves` types, `BucketCounts::add`/`total` helpers, `run_reserve_side`/`print_reserve_side`/`reserve_side_json`/`build_market_summary_json` helpers, plus 8 new unit tests covering bucket aggregation, non-green detection, and market-summary JSON shape.
- `src/main.rs` — dispatch branch.
- `src/constants.rs` — help text + examples.
- `docs/CLI.md` — quick-ref table entry, full section under "Event-replay validation", combination-rules update.

## Test plan

- [x] `cargo check` clean.
- [x] `cargo clippy -- -D warnings` clean.
- [x] `cargo test --lib` — 44 tests pass (8 new).
- [x] Parser smoke tests: `--calculate-from-events-reserve-all --verbose` correctly rejected; `--a-token-only` + `--debt-token-only` correctly mutex; unrelated companions like `--reserve-token` correctly rejected; `--a-token-only` / `--verbose` / `--json` alone correctly rejected with updated error messages; valid combinations parse cleanly. Single-reserve `--calculate-from-events-reserve … --verbose` still parses (unchanged behavior).
- [ ] **End-to-end run against the populated prod-like MongoDB** to confirm output format and re-validate the canary baseline pattern across all reserves (worth doing before merge — only one `SIGNIFICANT` row on `sodaSUI` borrow side is expected based on PR #36's findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)