### PR TITLE
chore: replace emoji verdict markers with ASCII tags

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -478,7 +478,7 @@ cargo run -- --calculate-from-events-reserve 0xreserve... --json
 
 Market-wide variant of `--calculate-from-events-reserve`: iterates **every reserve** returned by `find_all_reserves()` and runs the same per-user × per-side scaled-vs-scaled comparison for each. Designed for a regular health check across the whole money market — no need to keep a hand-maintained list of reserve addresses in sync.
 
-For each reserve the output mirrors the single-reserve flag's compact-table format (one supply table + one borrow table, with the same `Position Scaled` column and `Verdict` classification). At the end, the handler prints a **market-wide summary**: total reserves processed, aggregate verdict bucket counts (separately per side), and the list of reserves that contributed any `SIGNIFICANT` (❌), `MINOR` (⚠️), or `ERROR` (‼️) row on either side.
+For each reserve the output mirrors the single-reserve flag's compact-table format (one supply table + one borrow table, with the same `Position Scaled` column and `Verdict` classification). At the end, the handler prints a **market-wide summary**: total reserves processed, aggregate verdict bucket counts (separately per side), and the list of reserves that contributed any `SIGNIFICANT` ([FAIL]), `MINOR` ([WARN]), or `ERROR` ([ERR]) row on either side.
 
 **Per-reserve behavior:**
 - Reuses the existing replay helpers (`replay_side`, `print_replay_table`, `rows_summary_json`, `count_buckets`) — no separate code path for the per-reserve work.

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -875,12 +875,12 @@ pub async fn handle_validate_token_all_generic(scaled: bool) {
         if let Some(error) = &validation_result.error {
           error_count += 1;
           output!(
-            "❌ Reserve {}: ERROR - {}",
+            "[FAIL] Reserve {}: ERROR - {}",
             validation_result.reserve_address, error
           );
         } else {
           output!(
-            "✅ Reserve {} validated successfully",
+            "[OK] Reserve {} validated successfully",
             validation_result.reserve_address
           );
           output!(
@@ -901,11 +901,11 @@ pub async fn handle_validate_token_all_generic(scaled: bool) {
       }
       Ok(Err(e)) => {
         error_count += 1;
-        output!("❌ Validation failed: {}", e);
+        output!("[FAIL] Validation failed: {}", e);
       }
       Err(e) => {
         error_count += 1;
-        output!("❌ Task failed: {}", e);
+        output!("[FAIL] Task failed: {}", e);
       }
     }
   }
@@ -984,7 +984,7 @@ pub async fn handle_validate_users_all_generic(scaled: bool) {
       }
       Err(e) => {
         error_count += 1;
-        output!("❌ Task failed: {}", e);
+        output!("[FAIL] Task failed: {}", e);
       }
     }
   }
@@ -1049,14 +1049,14 @@ async fn handle_user_validation_generic(user_address: &str, exit_on_error: bool,
     }
   };
   output!(
-    "✅ User {}: {} positions validated",
+    "[OK] User {}: {} positions validated",
     result.user_address,
     result.positions.len()
   );
   for position in &result.positions {
     if let Some(error) = &position.error {
       output!(
-        "  ❌ Reserve {}: ERROR - {}",
+        "  [FAIL] Reserve {}: ERROR - {}",
         position.reserve_address, error
       );
     } else {
@@ -1542,13 +1542,13 @@ pub async fn handle_calculate_from_events(flags: Vec<Flag>) {
           output!("Percentage:         {:.4}%", percentage);
 
           if diff == 0 {
-            output!("\n✅ Perfect match!");
+            output!("\n[OK] Perfect match!");
           } else if percentage < 0.01 {
-            output!("\n✅ Excellent match (< 0.01% difference)");
+            output!("\n[OK] Excellent match (< 0.01% difference)");
           } else if percentage < 1.0 {
-            output!("\n⚠️  Minor mismatch (< 1% difference)");
+            output!("\n[WARN]  Minor mismatch (< 1% difference)");
           } else {
-            output!("\n❌ Significant mismatch (>= 1% difference)");
+            output!("\n[FAIL] Significant mismatch (>= 1% difference)");
           }
         }
         Err(e) => {
@@ -1730,7 +1730,7 @@ pub async fn handle_validate_from_events_all() {
           if let Some(ref err) = result.error {
             error_count += 1;
             println!(
-              "  ❌ User {} | Reserve {}: {}",
+              "  [FAIL] User {} | Reserve {}: {}",
               result.user_address, result.reserve_address, err
             );
             continue;
@@ -1885,7 +1885,7 @@ async fn validate_position_from_events(
     Err(e) => {
       if verbose {
         println!(
-          "  ⚠️  Supply validation error for reserve {}: {}",
+          "  [WARN]  Supply validation error for reserve {}: {}",
           reserve_address, e
         );
       }
@@ -1914,7 +1914,7 @@ async fn validate_position_from_events(
     Err(e) => {
       if verbose {
         println!(
-          "  ⚠️  Borrow validation error for reserve {}: {}",
+          "  [WARN]  Borrow validation error for reserve {}: {}",
           reserve_address, e
         );
       }
@@ -2045,7 +2045,7 @@ async fn validate_side_from_events(
 fn print_event_validation_result(result: &EventValidationResult) {
   if let Some(ref err) = result.error {
     println!(
-      "❌ User {} | Reserve {}: {}",
+      "[FAIL] User {} | Reserve {}: {}",
       result.user_address, result.reserve_address, err
     );
   }
@@ -2079,14 +2079,14 @@ fn print_three_way(
     && comparison.db_vs_chain_diff == 0
     && comparison.events_vs_db_diff == 0
   {
-    "✅"
+    "[OK]"
   } else if comparison.events_vs_chain_pct < 1.0
     && comparison.db_vs_chain_pct < 1.0
     && comparison.events_vs_db_pct < 1.0
   {
-    "⚠️"
+    "[WARN]"
   } else {
-    "❌"
+    "[FAIL]"
   };
 
   println!(
@@ -2593,10 +2593,10 @@ impl ReserveReplayRow {
 
   fn verdict_symbol(&self) -> &'static str {
     match self.verdict() {
-      "PERFECT" | "EXCELLENT" => "✅",
-      "MINOR" => "⚠️",
-      "ERROR" => "‼️",
-      _ => "❌",
+      "PERFECT" | "EXCELLENT" => "[OK]",
+      "MINOR" => "[WARN]",
+      "ERROR" => "[ERR]",
+      _ => "[FAIL]",
     }
   }
 }
@@ -2960,7 +2960,7 @@ fn print_replay_table(label: &str, token_address: &str, rows: &[ReserveReplayRow
 
   let c = count_buckets(rows);
   output!(
-    "\nSummary ({}): {} users  ·  ✅ {} perfect / {} excellent  ·  ⚠️ {} minor  ·  ❌ {} significant  ·  ‼️ {} errors",
+    "\nSummary ({}): {} users  ·  [OK] {} perfect / {} excellent  ·  [WARN] {} minor  ·  [FAIL] {} significant  ·  [ERR] {} errors",
     label,
     rows.len(),
     c.perfect,
@@ -3299,13 +3299,13 @@ fn print_reserve_side(label: &str, token_address: &str, result: &ReserveSideResu
       // one error line plus the standard summary so aggregate counts stay readable.
       output!("\n=== {} ({}) ===", label, token_address);
       output!(
-        "‼️ Fetch failed: {} ({} users counted as ERROR)",
+        "[ERR] Fetch failed: {} ({} users counted as ERROR)",
         err,
         result.rows.len()
       );
       let c = count_buckets(&result.rows);
       output!(
-        "\nSummary ({}): {} users  ·  ✅ {} perfect / {} excellent  ·  ⚠️ {} minor  ·  ❌ {} significant  ·  ‼️ {} errors",
+        "\nSummary ({}): {} users  ·  [OK] {} perfect / {} excellent  ·  [WARN] {} minor  ·  [FAIL] {} significant  ·  [ERR] {} errors",
         label,
         result.rows.len(),
         c.perfect,
@@ -3576,7 +3576,7 @@ pub async fn handle_calculate_from_events_reserve_all(flags: Vec<Flag>) {
   output!("Reserves processed: {}", total);
   if do_supply {
     output!(
-      "Supply users: {}  ·  ✅ {} / {}  ·  ⚠️ {}  ·  ❌ {}  ·  ‼️ {}",
+      "Supply users: {}  ·  [OK] {} / {}  ·  [WARN] {}  ·  [FAIL] {}  ·  [ERR] {}",
       market_supply.total(),
       market_supply.perfect,
       market_supply.excellent,
@@ -3587,7 +3587,7 @@ pub async fn handle_calculate_from_events_reserve_all(flags: Vec<Flag>) {
   }
   if do_borrow {
     output!(
-      "Borrow users: {}  ·  ✅ {} / {}  ·  ⚠️ {}  ·  ❌ {}  ·  ‼️ {}",
+      "Borrow users: {}  ·  [OK] {} / {}  ·  [WARN] {}  ·  [FAIL] {}  ·  [ERR] {}",
       market_borrow.total(),
       market_borrow.perfect,
       market_borrow.excellent,
@@ -3607,15 +3607,15 @@ pub async fn handle_calculate_from_events_reserve_all(flags: Vec<Flag>) {
     format!("{} ({})", list.len(), items.join(", "))
   };
   output!(
-    "Reserves with at least one ❌: {}",
+    "Reserves with at least one [FAIL]: {}",
     fmt_list(&non_green.significant)
   );
   output!(
-    "Reserves with at least one ⚠️: {}",
+    "Reserves with at least one [WARN]: {}",
     fmt_list(&non_green.minor)
   );
   output!(
-    "Reserves with at least one ‼️: {}",
+    "Reserves with at least one [ERR]: {}",
     fmt_list(&non_green.errors)
   );
   output!("\n=== Money Market Event-Replay Reconstruction Complete ===");
@@ -3695,7 +3695,7 @@ mod tests {
   fn verdict_perfect_when_diff_zero() {
     let row = ok_row(0, 100);
     assert_eq!(row.verdict(), "PERFECT");
-    assert_eq!(row.verdict_symbol(), "✅");
+    assert_eq!(row.verdict_symbol(), "[OK]");
   }
 
   #[test]
@@ -3703,7 +3703,7 @@ mod tests {
     // 1/20_000 = 0.005% — well under the 0.01% EXCELLENT cutoff.
     let row = ok_row(1, 20_000);
     assert_eq!(row.verdict(), "EXCELLENT");
-    assert_eq!(row.verdict_symbol(), "✅");
+    assert_eq!(row.verdict_symbol(), "[OK]");
   }
 
   #[test]
@@ -3711,7 +3711,7 @@ mod tests {
     // 5/10_000 = 0.05% — between the EXCELLENT and SIGNIFICANT thresholds.
     let row = ok_row(5, 10_000);
     assert_eq!(row.verdict(), "MINOR");
-    assert_eq!(row.verdict_symbol(), "⚠️");
+    assert_eq!(row.verdict_symbol(), "[WARN]");
   }
 
   #[test]
@@ -3719,7 +3719,7 @@ mod tests {
     // 1/100 = exactly 1% → SIGNIFICANT (≥ branch).
     let at = ok_row(1, 100);
     assert_eq!(at.verdict(), "SIGNIFICANT");
-    assert_eq!(at.verdict_symbol(), "❌");
+    assert_eq!(at.verdict_symbol(), "[FAIL]");
     let above = ok_row(100, 200);
     assert_eq!(above.verdict(), "SIGNIFICANT");
   }
@@ -3729,7 +3729,7 @@ mod tests {
     let mut row = ok_row(0, 0);
     row.error = Some("boom".to_string());
     assert_eq!(row.verdict(), "ERROR");
-    assert_eq!(row.verdict_symbol(), "‼️");
+    assert_eq!(row.verdict_symbol(), "[ERR]");
   }
 
   #[test]

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -160,7 +160,7 @@ pub fn compare_and_report_diff(
   description: &str,
 ) -> String {
   if calculated_amount == on_chain_amount {
-    format!("✅ {} amounts match: {}", description, calculated_amount)
+    format!("[OK] {} amounts match: {}", description, calculated_amount)
   } else {
     let diff = calculated_amount.abs_diff(on_chain_amount);
     let percentage = (diff as f64 / on_chain_amount as f64) * 100.0;
@@ -170,7 +170,7 @@ pub fn compare_and_report_diff(
     // this value is 1000000 wei
     if diff < 1_000_000 {
       return format!(
-        "⚠️ Minor mismatch for {}: calculated = {}, on-chain = {}, diff = {} ({:.4})%",
+        "[WARN] Minor mismatch for {}: calculated = {}, on-chain = {}, diff = {} ({:.4})%",
         description, calculated_amount, on_chain_amount, diff, percentage
       );
     }
@@ -180,12 +180,12 @@ pub fn compare_and_report_diff(
     // percentage is below 0.01%
     if percentage < 0.01 {
       return format!(
-        "⚠️ Minor mismatch for {}: calculated = {}, on-chain = {}, diff = {} ({:.4})%",
+        "[WARN] Minor mismatch for {}: calculated = {}, on-chain = {}, diff = {} ({:.4})%",
         description, calculated_amount, on_chain_amount, diff, percentage
       );
     }
     format!(
-      "❌ Mismatch for {}: calculated = {}, on-chain = {}, diff = {} ({:.4})%",
+      "[FAIL] Mismatch for {}: calculated = {}, on-chain = {}, diff = {} ({:.4})%",
       description, calculated_amount, on_chain_amount, diff, percentage
     )
   }


### PR DESCRIPTION
## Summary

Reports include the canary output, and terminals / locales that don't render multi-byte UTF-8 emoji display the bytes as garbled escape sequences (e.g. \`[OK]\` was rendering as \`~\\~E\` in the canary server's console), making the report effectively unreadable and hard to share.

Replace the four emoji markers with bracketed ASCII tags that render identically in every terminal:

| Was | Now | Meaning |
|---|---|---|
| \`✅\` | \`[OK]\`   | PERFECT / EXCELLENT / DUST |
| \`⚠️\` | \`[WARN]\` | MINOR |
| \`❌\` | \`[FAIL]\` | SIGNIFICANT |
| \`‼️\` | \`[ERR]\`  | ERROR (fetch / RPC failures) |

Pure cosmetic — **no behavior change**. Touches every \`output!\` call that formatted a verdict marker:
- per-row table verdict column
- per-side summary line
- per-side fetch-failed fallback summary
- market-wide summary
- \"Reserves with at least one X\" footer lines
- \`src/helpers.rs\` validator output
- \`docs/CLI.md\` reference
- test assertions on \`verdict_symbol()\`

## Test plan

- [x] \`cargo check\` — clean
- [x] \`cargo clippy -- -D warnings\` — clean
- [x] \`cargo test --lib\` — 44/44 passing (test assertions updated to match new strings)
- [x] Grep verified zero remaining emoji bytes in \`src/\` and \`docs/\` after replacement

## Conflict note vs. PR #40

PR #40 (DUST bucket) modifies the same summary printf strings to add a dust column. Whichever lands second will need a small reconciliation in the summary printfs (apply ASCII conversion to the new dust lines, or add dust column to the ASCII-converted lines). One-line conflict; trivial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)